### PR TITLE
interviewProvider useReducer 방식으로 로직 개선

### DIFF
--- a/apps/client/src/domains/interview/types/index.ts
+++ b/apps/client/src/domains/interview/types/index.ts
@@ -1,8 +1,8 @@
-type RobotStatus =
+type InterviewStatus =
   | "standby"
   | "thinking"
   | "question"
   | "finished"
   | "beforeStart";
 
-export type { RobotStatus };
+export type { InterviewStatus };


### PR DESCRIPTION
# 리뷰 요청
안녕하세요 멘토님! 코드 리뷰 요청 드립니다.
이번에 mvp를 만들면서 너무 코드를 막 썼었던 것 같아서 기존 코드를 분석하고 제가 내린 나름의 개선 방안으로 리팩토링을 진행했습니다.
아래는 제가 리팩토링 하면서 적었던 글입니다!

리뷰 요청을 드리게 된 이유는 아래 리팩토링 하면서 글을 쓴 것과 같이
`InterviewProvider`같은 경우에 인터뷰의 상태를 내려주기 위한 provider인데, 이 상태를 관리 하는 것이 하나의 책임이라고 생각하면, `answerQuestion`과 같이 질문에 대해 에러 분기 및 다음 메시지를 처리하는 로직과 같은  부분 또한 별도의 책임 하나를 더 들고 간다고 생각했습니다.
 그렇다면 이 `answerQuestion`이나 , 인터뷰를 시작할 때 쓰는 `interviewStartup` 과 같은 부분은 해당 도메인의 컴포넌트에 책임을 분산하는 것이 맞을까에 대한 고민에 대해 여쭙고 싶습니다.

그렇게 된다면 예를 들어, 해당 provider 내에 있는 answerQuestion같은 경우
```tsx
export function InterviewAnswerInput() {
  const [interviewInput, setInterviewInput] = useState<string>("");
  const { status, answerQuestion } = useInterviewContext();
  const handleClick = async () => {
    const inputValue = interviewInput;
    setInterviewInput("");
    try {
      await answerQuestion(inputValue || "");
      // 여기에 answerQuestion 내의 로직이 오는 것을 생각했습니다.
    } catch {
      setInterviewInput(inputValue);
    }
  };

  return (
    <div className="absolute z-20 bottom-10 gap-3 p-4 items-center w-3/4 left-[10%] border border-border-input rounded-xl bg-background-base ">
      <AnswerInput
        onChange={(e) => setInterviewInput(e.target.value)}
        value={interviewInput}
      />
      <div className="flex w-full gap-5">
        <div className="flex-1"></div>
        <Button
          shadow={"none"}
          border={"round"}
          className={`w-[50px] h-[50px] disabled:opacity-50 disabled:pointer-events-none transition-opacity duration-200`}
          disabled={status !== "question" || !interviewInput.length}
          onClick={() => handleClick()}
        >
          <ArrowBigUp className="text-primary-content" />
        </Button>
      </div>
    </div>
  );
}
```
위 주석에 단 것 같이 버튼 쪽에 `answerQuestion`의 로직이 오게 되는데, 이러한 방향이 맞나에 대해서 여쭙고 싶습니다!

## 면접 페이지의 Provider 리팩토링
```tsx
import { RobotStatus } from "@/domains/interview/types";
import axios from "axios";
import { useRouter } from "next/navigation";
import { createContext, useContext, useState } from "react";

interface InterviewProviderProps {
  children: React.ReactNode;
  interviewId: number;
  message: string;
  status: RobotStatus;
  rootQuestion: string;
  answerQuestion: (answer: string) => Promise<void>;
  exit: () => void;
  interviewStartup: () => void;
}

const InterviewContext = createContext<InterviewProviderProps | null>(null);

const INTERVIEW_STARTUP = [
  "안녕하세요! 반갑습니다.",
  "면접에 참여해주셔서 감사합니다",
  "면접은 편하게 진행되니, 긴장하지 마세요.",
  "면접이 끝나면, 피드백을 드릴 예정입니다.",
  "면접을 시작하겠습니다.",
];

export const InterviewProvider = ({
  children,
  interviewId,
  questionId,
  rootQuestion,
}: {
  children: React.ReactNode;
  interviewId: number;
  questionId: number;
  rootQuestion: string;
}) => {
  const [message, _setMessage] = useState<string>("");
  const [status, _setStatus] = useState<RobotStatus>("beforeStart");
  const [currentQuestionId, setCurrentQuestionId] =
    useState<number>(questionId);
  const navigate = useRouter();

  const interviewStartup = () => {
    _setStatus("standby");
    startupMessage(0);
  };
  const startupMessage = (startupIdx: number) => {
    if (startupIdx < INTERVIEW_STARTUP.length) {
      changeMessage(INTERVIEW_STARTUP[startupIdx]);
      setTimeout(() => startupMessage(startupIdx + 1), 2000);
      return;
    }
    if (startupIdx === INTERVIEW_STARTUP.length) {
      changeMessage(rootQuestion);
      _setStatus("question");
      return;
    }
  };

  const changeMessage = (newMessage: string) => {
    _setMessage(newMessage);
  };

  const answerQuestion = async (answer: string) => {
    const prevMessage = message;
    try {
      _setStatus("thinking");
      const response = await axios.post(
        `/api/interviews/${interviewId}/questions/${currentQuestionId ?? questionId}/answers`,
        {
          interview_id: interviewId,
          question_id: currentQuestionId ?? questionId,
          answer,
        },
        {
          headers: {
            "Content-Type": "application/json",
          },
          timeout: 10000,
        }
      );
      if (response.status === 204) {
        _setStatus("finished");
        changeMessage("면접이 종료되었습니다. 고생 많으셨습니다.");
        setTimeout(() => {
          navigate.replace(`/interview/${interviewId}/result`);
        }, 3000);
        return;
      }
      changeMessage(response.data.question);
      _setStatus("question");
      setCurrentQuestionId(response.data.question_id);
    } catch {
      _setStatus("standby");
      changeMessage("답변을 제출하는데 실패했습니다. 다시 시도해주세요.");
      setTimeout(() => {
        _setStatus("question");
        changeMessage(prevMessage);
      }, 2000);
    }
  };

  const exit = () => {
    if (status === "beforeStart") {
      navigate.back();
      return;
    }
  };


};

export function useInterviewContext() {
  const context = useContext(InterviewContext);
  if (!context) {
    throw new Error(
      "useInterviewContext must be used within an InterviewProvider"
    );
  }
  return context;
}

```

가장 먼저 리팩토링을 할 대상은 이 `InterviewProvider`이다.

일단 해당 코드의 냄새를 맡아보자.
## 코드 냄새 맡아보기 👃
### 1. 불필요한 props 없애기
```tsx

  return (
    <InterviewContext.Provider
      value={{
        exit,
        children,
        interviewId,
        message,
        status,
        rootQuestion,
        answerQuestion,
        interviewStartup,
      }}
    >
      {children}
    </InterviewContext.Provider>
  );
```
이건 왜 그랬지..? 어지간히 급했나보다
`children` props는 딱히 provider로 내려줄 필요가 없기 때문에 Provider 컴포넌트에서 받은 children은 `Provider의 children`으로만 가게 했다.

```tsx
<InterviewContext.Provider
      value={{
        exit,
        children,
        interviewId,
        message,
        status,
        rootQuestion,
        answerQuestion,
        interviewStartup,
      }}
    >
      {children}
    </InterviewContext.Provider>
```

### 2. 상태와 타입의 네이밍
지금 관리하고 있는 상태의 경우 세 가지가 있다. 
```tsx
const [message, _setMessage] = useState<string>("");
const [status, _setStatus] = useState<RobotStatus>("beforeStart");
const [currentQuestionId, setCurrentQuestionId] =
    useState<number>(questionId);
```
- message : 면접관이 질문할 때 보여주는 메시지
- status : 면접관의 상태(`시작 전 | 대기 | 질문 중 | 질문 제출 후 대기 | 면접 끝 `)
- currentQuestionId : 질문과 함께 해당 질문에 대한 대답을 post 요청으로 보내기 위한 id값

하지만
- message의 경우에, 어떤 메시지인지 조금 모호한 감이 있다
- `status`의 타입같은 경우, `RobotStatus`를 타입으로 가지고 있는데, 사실상 면접 자체의 상태를 나타내는 것인데 `로봇의 상태`라는 네이밍 자체가 애매하다.

### 3. 상태의 업데이트
`시작 전 | 대기 | 질문 중 | 질문 제출 후 대기 | 면접 끝 `

현재는 다섯 개의 status 상태를 가지고 있는데, 이 상태가 변경되는 경우는 명확하게 구분되어 있으면서, 메시지 또한 함께 가는 경우가 많다.
- 질문 중 -> 첫 질문이나 질문 제출 후 다른 질문을 받았을 때
- 질문 제출 후 대기 -> 서버에게 답변 제출 후 다음 질문이나 면접 끝 전까지
- 면접 끝 -> 서버로부터 204 `no Content` 응답을 받았을 때
- 시작 전 -> 면접 시작 버튼을 누르기 전 
- 대기 -> 인터뷰 시작하면서 안내사항 전달할 때
이렇게 상태를 명확하게 나누고, 업데이트 할 때가 명확하게 정해져 있으며 message와 같이 복수의 상태가 함께 바뀌게 된다면 `useReducer`를 통해서 각 로직을 하나로 묶어줄 수 있다.

```tsx
if (response.status === 204) {
        _setStatus("finished");
        changeMessage("면접이 종료되었습니다. 고생 많으셨습니다.");
        setTimeout(() => {
          navigate.replace(`/interview/${interviewId}/result`);
        }, 3000);
        return;
      }
      changeMessage(response.data.question);
      _setStatus("question");
      setCurrentQuestionId(response.data.question_id);
    } catch {
      _setStatus("standby");
      changeMessage("답변을 제출하는데 실패했습니다. 다시 시도해주세요.");
      setTimeout(() => {
        _setStatus("question");
        changeMessage(prevMessage);
      }, 2000);
    }
```
그렇게 된다면 message와 status를 하나로 묶어서 실행할 수도 있고, 각 상태 변경이 명확한 시점에 대해서 reducer를 정의해 놓는다면 이 로직이 어떻게 동작할 지를 더 명확하게 파악할 수 있을 것이다.

### 4. 과중되어 있는 책임
기존의 코드의 경우, 
- 인터뷰 시작 코멘트에 대한 메시지 변경
- 인터뷰 종료 시 밖으로 나가기
- 그 외 상태변경 등 인터뷰 진행 전반 모든 로직
등 상태만을 변경하는 것 말고도 많은 책임을 가지고 있다.

```tsx
  const exit = () => {
    if (status === "beforeStart") {
      navigate.back();
      return;
    }
  };
```
대표적인 예가 이 `exit` 함수이다.  면접을 시작하기 전에는 모달을 통해서 

![](https://i.imgur.com/zTryUgX.png)
이렇게 띄워주고 있는데, 결국 이 모달이 가지는 책임마저 Provider가 가지게 되는 문제가 발생한다.
그렇게 되면 Provider 자체가 가지고 있는 책임이 가중되어 이러한 책임을 분산시킬 필요가 있다고 판단했다.
그 외에도
```tsx
if (response.status === 204) {
        dispatch({ type: "QUESTION", payload: { status: "finished" } });
        setTimeout(() => {
          navigate.replace(`/interview/${interviewId}/result`);
        }, 3000);
        return;
      }
```
면접이 끝났을 때도 setTimeout을 통해서 결과 페이지로 이동하는 로직 자체가 answerQuestion 안에 함께 넣다 보니 `answerQuestion` 자체도 `다음 문제 처리, 에러시 롤백처리, 마지막 문제 후 결과 페이지로 이동` 등 과중한 책임을 가지게 된다. 따라서 이 router 훅 자체도 바깥으로 빼서 필요한 컴포넌트로 책임을 분산해야겠다고 생각했다.


## 리팩토링 후
```tsx
import { submitInterviewAnswer } from "@/domains/interview/api/interviewAnswer";
import { InterviewStatus } from "@/domains/interview/types";
import { createContext, useContext, useReducer } from "react";

interface InterviewProviderProps {
  interviewId: number;
  message: string;
  status: InterviewStatus;
  rootQuestion: string;
  answerQuestion: (answer: string) => Promise<void>;
  interviewStartup: () => void;
}

const InterviewContext = createContext<InterviewProviderProps | null>(null);

const INTERVIEW_STARTUP =
  "안녕하세요! 꼬꼬면 면접에 오신 것을 환영합니다. 면접을 시작하겠습니다.";
const INTERVIEW_SUBMIT_FAILED = "답변 제출에 실패했습니다. 다시 시도해주세요.";
interface InterviewState {
  message: string;
  status: InterviewStatus;
  currentQuestionId: number;
}
interface InterviewAction {
  type:
    | "ANSWER_QUESTION"
    | "START_UP"
    | "INTERVIEW_END"
    | "QUESTION"
    | "SUBMIT_FAILED";
  payload: {
    message?: string;
    status?: InterviewStatus;
    currentQuestionId?: number | null;
  };
}

function reducer(
  state: InterviewState,
  action: InterviewAction
): InterviewState {
  switch (action.type) {
    case "ANSWER_QUESTION":
      return {
        ...state,
        status: "thinking",
      };
    case "START_UP":
      return {
        ...state,
        status: "standby",
        message: INTERVIEW_STARTUP,
      };
    case "INTERVIEW_END":
      return {
        ...state,
        status: "finished",
        message: "면접이 종료되었습니다.",
      };
    case "QUESTION":
      return {
        ...state,
        message: action?.payload?.message as string,
        status: "question",
        currentQuestionId: action?.payload?.currentQuestionId as number,
      };
    case "SUBMIT_FAILED":
      return {
        ...state,
        status: "standby",
        message: INTERVIEW_SUBMIT_FAILED,
      };
    default:
      return state;
  }
}

export const InterviewProvider = ({
  children,
  interviewId,
  questionId,
  rootQuestion,
}: {
  children: React.ReactNode;
  interviewId: number;
  questionId: number;
  rootQuestion: string;
}) => {
  const [state, dispatch] = useReducer(reducer, {
    message: INTERVIEW_STARTUP,
    status: "beforeStart",
    currentQuestionId: questionId,
  });

  const interviewStartup = () => {
    dispatch({ type: "START_UP", payload: {} });
    setTimeout(
      () => dispatch({ type: "QUESTION", payload: { message: rootQuestion } }),
      2000
    );
  };

  const answerQuestion = async (answer: string) => {
    const prevMessage = state.message;
    try {
      dispatch({ type: "QUESTION", payload: { status: "thinking" } });
      const response = await submitInterviewAnswer({
        answer: answer,
        interview_id: interviewId,
        question_id: state.currentQuestionId,
      });
      if (response.status === 204) {
        dispatch({ type: "QUESTION", payload: { status: "finished" } });
        return;
      }
      dispatch({
        type: "QUESTION",
        payload: {
          status: "question",
          message: response.data.question,
          currentQuestionId: response.data.question_id,
        },
      });
    } catch {
      dispatch({ type: "SUBMIT_FAILED", payload: {} });
      setTimeout(() => {
        dispatch({
          type: "QUESTION",
          payload: { message: prevMessage, status: "question" },
        });
      }, 2000);
    }
  };

  return (
    <InterviewContext.Provider
      value={{
        interviewId,
        message: state.message,
        status: state.status,
        rootQuestion,
        answerQuestion,
        interviewStartup,
      }}
    >
      {children}
    </InterviewContext.Provider>
  );
};

export function useInterviewContext() {
  const context = useContext(InterviewContext);
  if (!context) {
    throw new Error(
      "useInterviewContext must be used within an InterviewProvider"
    );
  }
  return context;
}

```
이전에 봤었던 파악하기 어려웠던 로직들이 보다 정리됐고, `dispatch type`을 통해 상태 변경 로직 자체를 명확히 볼 수 있어 무엇을 하고자 하는 로직인지 잘 보인다고 생각한다.

## 다시 고민하기 🤔
`InterviewProvider`같은 경우에 인터뷰의 상태를 내려하기 위한 provider이다.
그렇기 때문에 이 상태를 관리 하는 것이 하나의 책임이라고 생각하면, `answerQuestion`과 같이 질문에 대해 에러 분기 및 다음 메시지를 처리하는 로직과 같은  부분 또한 별도의 책임 하나를 더 들고 간다고 생각할 수 있다. 그렇다면 이 `answerQuestion`이나 , 인터뷰를 시작할 때 쓰는 `interviewStartup` 과 같은 부분은 해당 도메인의 컴포넌트에 책임을 분산하는 것이 좋을까?