### PR TITLE
[Hotfix/cd] - workflow cd 경로변경 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,6 @@ jobs:
 
       - name: Run Docker Compose
         run: |
-          cd kokomen-client
           docker system prune -f
           docker compose -f compose.yaml down || true
           docker compose -f compose.yaml up -d --build


### PR DESCRIPTION
# HOTFIX

Workflow 실행 과정중에 cd로 self-hosted runner에서 cd 경로변경을 하게 되면, 현재 워킹 디렉토리에서 다시 이동하는 형태로 되어버려 실제로는 없는 디렉토리를 바라보고 있는 문제가 있어, cd 명령어를 제거했습니다.