### PR TITLE
[Feat/#30] - 사용자 닉네임 설정 페이지

### DIFF
--- a/apps/client/__tests__/authorization.test.tsx
+++ b/apps/client/__tests__/authorization.test.tsx
@@ -1,17 +1,3 @@
-jest.mock("next/router", () => ({
-  useRouter() {
-    return {
-      push: jest.fn(),
-      query: {
-        code: "testCode",
-        redirectTo: "",
-      },
-      replace: jest.fn(),
-    };
-  },
-}));
-jest.mock("");
-
 import LoginPage from "@/pages/login";
 import KakaoCallbackPage from "@/pages/login/callback";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -19,7 +5,7 @@ import { server } from "@/mocks";
 import { delay, http, HttpResponse } from "msw";
 import { renderWithProviders } from "@/utils/test-utils";
 import "@testing-library/jest-dom";
-import { act } from "react";
+import { mockReplace } from "jest.setup";
 
 describe("Oauth 카카오 로그인 테스트", () => {
   it("카카오 로그인 버튼이 렌더링 되는지 테스트", () => {
@@ -46,16 +32,6 @@ describe("로그인 페이지가 제대로 이동하는지 테스트", () => {
 
 describe("Oauth 로그인 버튼 누른 후 리다이렉트 페이지 테스트", () => {
   it("각 단계별 상태 ui가 렌더링되는지 확인하는 테스트", async () => {
-    const mockPush = jest.fn();
-    const mockReplace = jest.fn();
-
-    jest.spyOn(require("next/router"), "useRouter").mockReturnValue({
-      isReady: true,
-      push: mockPush,
-      replace: mockReplace,
-      query: { code: "testCode", state: "testState" },
-    });
-
     server.use(
       http.post(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/kakao-login`,
@@ -84,16 +60,6 @@ describe("Oauth 로그인 버튼 누른 후 리다이렉트 페이지 테스트"
   });
 
   it("API 호출이 완료되었을 때 정상적인 ui가 렌더링되는지 확인", async () => {
-    const mockPush = jest.fn();
-    const mockReplace = jest.fn();
-
-    jest.spyOn(require("next/router"), "useRouter").mockReturnValue({
-      isReady: true,
-      push: mockPush,
-      replace: mockReplace,
-      query: { code: "testCode", state: "testState" },
-    });
-
     server.use(
       http.post(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/kakao-login`,
@@ -112,25 +78,16 @@ describe("Oauth 로그인 버튼 누른 후 리다이렉트 페이지 테스트"
     });
   });
 
-  it("API 호출 이후 3초 후 mockReplace가 실행되는지 확인", async () => {
-    // Jest 타이머 모킹
-    jest.useFakeTimers();
-
-    const mockPush = jest.fn();
-    const mockReplace = jest.fn();
-
-    jest.spyOn(require("next/router"), "useRouter").mockReturnValue({
-      isReady: true,
-      push: mockPush,
-      replace: mockReplace,
-      query: { code: "testCode", state: "testState" },
-    });
-
+  it("API 호출 이후 mockReplace가 실행되는지 확인", async () => {
     server.use(
       http.post(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/kakao-login`,
         () => {
-          return HttpResponse.json({ success: true });
+          return HttpResponse.json({
+            id: 1,
+            nickname: "오상훈",
+            profile_completed: true,
+          });
         }
       )
     );
@@ -139,25 +96,9 @@ describe("Oauth 로그인 버튼 누른 후 리다이렉트 페이지 테스트"
       <KakaoCallbackPage code="testCode" state="testState" />
     );
 
-    // 로그인 완료 상태까지 기다리기
-    await waitFor(() => {
-      expect(screen.getByText("로그인 완료!")).toBeInTheDocument();
-    });
-
-    // 아직 replace가 호출되지 않았는지 확인
-    expect(mockReplace).not.toHaveBeenCalled();
-
-    // 3초 시간을 앞당기기
-    await act(async () => {
-      jest.advanceTimersByTime(3000);
-    });
-
     // replace가 호출되었는지 확인
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalled();
     });
-
-    // 타이머 정리
-    jest.useRealTimers();
   });
 });

--- a/apps/client/__tests__/profileSetting.test.tsx
+++ b/apps/client/__tests__/profileSetting.test.tsx
@@ -1,0 +1,32 @@
+import { server } from "@/mocks";
+import KakaoCallbackPage from "@/pages/login/callback";
+import { renderWithProviders } from "@/utils/test-utils";
+import { waitFor } from "@testing-library/dom";
+import { mockReplace } from "jest.setup";
+import { delay, http, HttpResponse } from "msw";
+
+describe("profile setting 페이지 이동 테스트", () => {
+  it("로그인 페이지에서 프로필 설정 페이지로 이동하는지 테스트", async () => {
+    server.use(
+      http.post(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/kakao-login`,
+        async () => {
+          await delay(100);
+          return HttpResponse.json({
+            id: 1,
+            nickname: "오상훈",
+            profile_completed: false,
+          });
+        }
+      )
+    );
+    renderWithProviders(<KakaoCallbackPage code="1234567890" state="test" />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/login/profile", {
+        query: {
+          redirectTo: "test",
+        },
+      });
+    });
+  });
+});

--- a/apps/client/__tests__/profileSetting.test.tsx
+++ b/apps/client/__tests__/profileSetting.test.tsx
@@ -2,7 +2,7 @@ import { server } from "@/mocks";
 import KakaoCallbackPage from "@/pages/login/callback";
 import LoginProfileSetting from "@/pages/login/profile";
 import { renderWithProviders } from "@/utils/test-utils";
-import { screen, waitFor } from "@testing-library/dom";
+import { fireEvent, screen, waitFor } from "@testing-library/dom";
 import { mockReplace } from "jest.setup";
 import { delay, http, HttpResponse } from "msw";
 
@@ -32,7 +32,7 @@ describe("profile setting 페이지 이동 테스트", () => {
   });
 });
 
-describe("profile setting 페이지 렌더링 테스트", () => {
+describe("profile setting 렌더링 테스트", () => {
   it("프로필 설정 페이지에서 제대로 유저 기본 필드값이 렌더링되는지 확인", async () => {
     renderWithProviders(
       <LoginProfileSetting
@@ -49,5 +49,93 @@ describe("profile setting 페이지 렌더링 테스트", () => {
     expect(screen.getByRole("textbox", { name: "닉네임" })).toHaveValue(
       "오상훈"
     );
+  });
+});
+
+describe("profile setting 기능 테스트", () => {
+  it("프로필 설정 페이지에서 닉네임 변경 테스트", async () => {
+    server.use(
+      http.post(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/me/profile`,
+        async () => {
+          await delay(100);
+          return HttpResponse.json({}, { status: 200 });
+        }
+      )
+    );
+    renderWithProviders(
+      <LoginProfileSetting
+        redirectTo="/"
+        userInfo={{
+          id: 1,
+          nickname: "오상훈",
+          score: 0,
+          token_count: 10,
+          profile_completed: false,
+        }}
+      />
+    );
+    const nicknameInput = screen.getByRole("textbox", { name: "닉네임" });
+    fireEvent.change(nicknameInput, { target: { value: "오상훈1234567" } });
+    expect(nicknameInput).toHaveValue("오상훈1234567");
+    const saveButton = screen.getByRole("button", { name: "저장하기" });
+    fireEvent.click(saveButton);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalled();
+    });
+  });
+  it("프로필 설정 페이지에서 유효하지 않은 값을 입력했을 때 닉네임  실패 테스트", async () => {
+    renderWithProviders(
+      <LoginProfileSetting
+        redirectTo="/"
+        userInfo={{
+          id: 1,
+          nickname: "오상훈",
+          score: 0,
+          token_count: 10,
+          profile_completed: false,
+        }}
+      />
+    );
+    const nicknameInput = screen.getByRole("textbox", { name: "닉네임" });
+    fireEvent.change(nicknameInput, { target: { value: "ㅇㅗㅅㅏㅇㅎㅜㄴ" } });
+    expect(nicknameInput).toHaveValue("ㅇㅗㅅㅏㅇㅎㅜㄴ");
+    const saveButton = screen.getByRole("button", { name: "저장하기" });
+    fireEvent.click(saveButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText("닉네임은 한글 조합, 영문, 숫자만 사용할 수 있습니다.")
+      ).toBeInTheDocument();
+    });
+
+    //20자 이하 테스트
+    fireEvent.change(nicknameInput, {
+      target: {
+        value: "오상훈1234567890123142214124214214214214",
+      },
+    });
+    expect(nicknameInput).toHaveValue(
+      "오상훈1234567890123142214124214214214214"
+    );
+    fireEvent.click(saveButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText("닉네임은 20자 이하이어야 합니다.")
+      ).toBeInTheDocument();
+    });
+
+    //3자 이상 테스트
+    fireEvent.change(nicknameInput, {
+      target: {
+        value: "오상",
+      },
+    });
+    expect(nicknameInput).toHaveValue("오상");
+    fireEvent.click(saveButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText("닉네임은 3자 이상이어야 합니다.")
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/client/__tests__/profileSetting.test.tsx
+++ b/apps/client/__tests__/profileSetting.test.tsx
@@ -1,7 +1,8 @@
 import { server } from "@/mocks";
 import KakaoCallbackPage from "@/pages/login/callback";
+import LoginProfileSetting from "@/pages/login/profile";
 import { renderWithProviders } from "@/utils/test-utils";
-import { waitFor } from "@testing-library/dom";
+import { screen, waitFor } from "@testing-library/dom";
 import { mockReplace } from "jest.setup";
 import { delay, http, HttpResponse } from "msw";
 
@@ -28,5 +29,25 @@ describe("profile setting 페이지 이동 테스트", () => {
         },
       });
     });
+  });
+});
+
+describe("profile setting 페이지 렌더링 테스트", () => {
+  it("프로필 설정 페이지에서 제대로 유저 기본 필드값이 렌더링되는지 확인", async () => {
+    renderWithProviders(
+      <LoginProfileSetting
+        redirectTo="/"
+        userInfo={{
+          id: 1,
+          nickname: "오상훈",
+          score: 0,
+          token_count: 10,
+          profile_completed: false,
+        }}
+      />
+    );
+    expect(screen.getByRole("textbox", { name: "닉네임" })).toHaveValue(
+      "오상훈"
+    );
   });
 });

--- a/apps/client/__tests__/profileSetting.test.tsx
+++ b/apps/client/__tests__/profileSetting.test.tsx
@@ -55,7 +55,7 @@ describe("profile setting 렌더링 테스트", () => {
 describe("profile setting 기능 테스트", () => {
   it("프로필 설정 페이지에서 닉네임 변경 테스트", async () => {
     server.use(
-      http.post(
+      http.patch(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/me/profile`,
         async () => {
           await delay(100);
@@ -83,6 +83,44 @@ describe("profile setting 기능 테스트", () => {
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalled();
     });
+  });
+  it("프로필 설정 페이지에서 닉네임 변경 실패 테스트", async () => {
+    server.use(
+      http.patch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/me/profile`,
+        async () => {
+          await delay(100);
+          return HttpResponse.json(
+            { message: "닉네임 변경에 실패 테스트" },
+            { status: 400 }
+          );
+        }
+      )
+    );
+    renderWithProviders(
+      <LoginProfileSetting
+        redirectTo="/"
+        userInfo={{
+          id: 1,
+          nickname: "오상훈",
+          score: 0,
+          token_count: 10,
+          profile_completed: false,
+        }}
+      />
+    );
+    const nicknameInput = screen.getByRole("textbox", { name: "닉네임" });
+    fireEvent.change(nicknameInput, { target: { value: "오상훈1234567" } });
+    expect(nicknameInput).toHaveValue("오상훈1234567");
+    const saveButton = screen.getByRole("button", { name: "저장하기" });
+    fireEvent.click(saveButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText("닉네임 변경에 실패했습니다.")
+      ).toBeInTheDocument();
+    });
+    //axios error의 메시지도 정상적으로 받아서 렌더링하는지 테스트
+    expect(screen.getByText("닉네임 변경에 실패 테스트")).toBeInTheDocument();
   });
   it("프로필 설정 페이지에서 유효하지 않은 값을 입력했을 때 닉네임  실패 테스트", async () => {
     renderWithProviders(

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -17,6 +17,7 @@
     "lhci:upload": "lhci upload"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "@kokomen/ui": "workspace:*",
     "@sentry/nextjs": "^9.31.0",
     "@tanstack/react-query": "^5.80.6",
@@ -25,7 +26,8 @@
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.59.0"
+    "react-hook-form": "^7.59.0",
+    "zod": "^3.25.74"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",

--- a/apps/client/src/domains/auth/api/index.ts
+++ b/apps/client/src/domains/auth/api/index.ts
@@ -11,6 +11,7 @@ const authServerInstance: AxiosInstance = axios.create({
 interface KakaoLoginResponse {
   id: number;
   nickname: string;
+  profile_completed: boolean;
 }
 
 const postAuthorizationCode = async (
@@ -47,4 +48,8 @@ const logout = async (): AxiosPromise<void> => {
   );
 };
 
-export { postAuthorizationCode, getUserInfo, logout };
+const updateUserProfile = async (nickname: string): AxiosPromise<void> => {
+  return authServerInstance.patch(`/members/me/profile`, { nickname });
+};
+
+export { postAuthorizationCode, getUserInfo, logout, updateUserProfile };

--- a/apps/client/src/domains/auth/components/profilesettingForm.tsx
+++ b/apps/client/src/domains/auth/components/profilesettingForm.tsx
@@ -2,7 +2,7 @@ import { useForm } from "react-hook-form";
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/router";
-import { errorToast } from "@kokomen/ui/hooks/useToast";
+import { useToast } from "@kokomen/ui/hooks/useToast";
 import { AxiosError } from "axios";
 import { User } from "../types";
 import z from "zod";
@@ -41,6 +41,7 @@ export default function ProfileSettingForm({
     },
   });
   const router = useRouter();
+  const { error: errorToast } = useToast();
   const { mutate: updateUserProfileMutation, isPending } = useMutation({
     mutationFn: updateUserProfile,
     onSuccess: () => {

--- a/apps/client/src/domains/auth/components/profilesettingForm.tsx
+++ b/apps/client/src/domains/auth/components/profilesettingForm.tsx
@@ -1,0 +1,95 @@
+import { useForm } from "react-hook-form";
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { errorToast } from "@kokomen/ui/hooks/useToast";
+import { AxiosError } from "axios";
+import { User } from "../types";
+import z from "zod";
+import { updateUserProfile } from "@/domains/auth/api";
+import { Input } from "@kokomen/ui/components/input";
+import { Button } from "@kokomen/ui/components/button";
+
+// eslint-disable-next-line @rushstack/typedef-var
+const ProfileSetting = z.object({
+  nickname: z
+    .string()
+    .min(3, { message: "닉네임은 3자 이상이어야 합니다." })
+    .max(20, { message: "닉네임은 20자 이하이어야 합니다." })
+    .regex(/^[가-힣a-zA-Z0-9]+$/, {
+      message: "닉네임은 한글 조합, 영문, 숫자만 사용할 수 있습니다.",
+    }),
+});
+type ProfileSettingType = z.infer<typeof ProfileSetting>;
+
+export default function ProfileSettingForm({
+  userInfo,
+  redirectTo,
+}: {
+  userInfo: User;
+  redirectTo: string;
+}) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm<ProfileSettingType>({
+    resolver: standardSchemaResolver(ProfileSetting),
+    defaultValues: {
+      nickname: userInfo.nickname,
+    },
+  });
+  const router = useRouter();
+  const { mutate: updateUserProfileMutation, isPending } = useMutation({
+    mutationFn: updateUserProfile,
+    onSuccess: () => {
+      router.replace(redirectTo ?? "/");
+    },
+    onError: (error: AxiosError) => {
+      errorToast({
+        title: "닉네임 변경에 실패했습니다.",
+        description:
+          (error.response?.data as { message: string }).message ??
+          "서버 오류가 발생했습니다.",
+      });
+    },
+  });
+
+  const onSubmit = (data: ProfileSettingType) => {
+    updateUserProfileMutation(data.nickname);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+      <div>
+        <label
+          htmlFor="nickname"
+          className="block text-sm font-medium text-gray-700 mb-2"
+        >
+          닉네임
+        </label>
+        <Input
+          {...register("nickname", { required: true })}
+          type="text"
+          className="w-full"
+          role="textbox"
+          placeholder="닉네임을 입력해주세요"
+          onChange={(e) => setValue("nickname", e.target.value)}
+        />
+        {errors.nickname && (
+          <p className="mt-2 text-sm text-red-600">{errors.nickname.message}</p>
+        )}
+      </div>
+      <Button
+        type="submit"
+        variant="primary"
+        className="w-full"
+        disabled={isPending}
+        aria-disabled={isPending}
+      >
+        저장하기
+      </Button>
+    </form>
+  );
+}

--- a/apps/client/src/domains/auth/types/index.ts
+++ b/apps/client/src/domains/auth/types/index.ts
@@ -3,6 +3,7 @@ interface User {
   nickname: string;
   score: number;
   token_count: number;
+  profile_completed: boolean;
 }
 
 export type { User };

--- a/apps/client/src/pages/dashboard/index.tsx
+++ b/apps/client/src/pages/dashboard/index.tsx
@@ -1,14 +1,20 @@
 import { getUserInfo } from "@/domains/auth/api";
 import Header from "@/shared/header";
 import { withCheckInServer } from "@/utils/auth";
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import {
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+  InferGetServerSidePropsType,
+} from "next";
 import Head from "next/head";
 import { Coins, User, Star } from "lucide-react";
 import InterviewHistory from "@/domains/dashboard/components/interviewHistory";
+import { User as UserType } from "@/domains/auth/types";
+import { JSX } from "react";
 
 export default function Dashboard({
   userInfo,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
   return (
     <>
       <Head>
@@ -59,11 +65,13 @@ export default function Dashboard({
 
 export const getServerSideProps = async (
   context: GetServerSidePropsContext
-) => {
+): Promise<GetServerSidePropsResult<{ userInfo: UserType }>> => {
   return withCheckInServer(async () => {
     const userInfo = await getUserInfo(context);
     return {
-      userInfo: userInfo.data,
+      data: {
+        userInfo: userInfo.data,
+      },
     };
   });
 };

--- a/apps/client/src/pages/login/callback.tsx
+++ b/apps/client/src/pages/login/callback.tsx
@@ -2,7 +2,7 @@ import { postAuthorizationCode } from "@/domains/auth/api";
 import { useMutation } from "@tanstack/react-query";
 import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 import { useRouter } from "next/router";
-import { JSX, useEffect, useState } from "react";
+import { JSX, useEffect } from "react";
 import Link from "next/link";
 
 type KakaoCallbackPageProps = {
@@ -15,7 +15,6 @@ export default function KakaoCallbackPage({
   state,
 }: KakaoCallbackPageProps): JSX.Element | null {
   const router = useRouter();
-  const [redirectCountdown, setRedirectCountdown] = useState(3);
 
   const authMutation = useMutation({
     mutationFn: ({
@@ -26,20 +25,19 @@ export default function KakaoCallbackPage({
       redirectUri: string;
     }) => postAuthorizationCode(code, redirectUri),
 
-    onSuccess: () => {
+    onSuccess: ({ data }) => {
+      if (!data.profile_completed) {
+        router.replace("/login/profile", {
+          query: {
+            redirectTo: state || "/",
+          },
+        });
+        return;
+      }
+
       // 3초 후 리다이렉트
       const redirectTo = state || "/";
-
-      const countdown = setInterval(() => {
-        setRedirectCountdown((prev) => {
-          if (prev <= 1) {
-            clearInterval(countdown);
-            router.replace(redirectTo);
-            return 0;
-          }
-          return prev - 1;
-        });
-      }, 1000);
+      router.replace(redirectTo);
     },
 
     onError: (error) => {
@@ -133,11 +131,7 @@ export default function KakaoCallbackPage({
             </p>
             <div className="space-y-4">
               <div className="text-sm text-gray-500">
-                {redirectCountdown > 0 ? (
-                  <span>{redirectCountdown}초 후 자동으로 이동합니다...</span>
-                ) : (
-                  <span>페이지를 이동 중입니다...</span>
-                )}
+                <span>페이지가 곧 이동됩니다...</span>
               </div>
               <Link
                 href={state || "/"}

--- a/apps/client/src/pages/login/profile.tsx
+++ b/apps/client/src/pages/login/profile.tsx
@@ -1,0 +1,158 @@
+import { getUserInfo, updateUserProfile } from "@/domains/auth/api";
+import { User } from "@/domains/auth/types";
+import { withCheckInServer } from "@/utils/auth";
+import {
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+  InferGetServerSidePropsType,
+} from "next";
+import Head from "next/head";
+import { JSX } from "react";
+import { Layout } from "@/components/layout";
+import Header from "@/shared/header";
+import { Input } from "@kokomen/ui/components/input";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { Button } from "@kokomen/ui/components/button";
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { errorToast } from "@kokomen/ui/hooks/useToast";
+import { AxiosError } from "axios";
+
+interface LoginProfileSettingProps {
+  userInfo: User;
+  redirectTo: string;
+}
+// eslint-disable-next-line @rushstack/typedef-var
+const ProfileSetting = z.object({
+  nickname: z
+    .string()
+    .min(3, { message: "닉네임은 3자 이상이어야 합니다." })
+    .max(20, { message: "닉네임은 20자 이하이어야 합니다." })
+    .regex(/^[가-힣a-zA-Z0-9]+$/, {
+      message: "닉네임은 한글 조합, 영문, 숫자만 사용할 수 있습니다.",
+    }),
+});
+type ProfileSettingType = z.infer<typeof ProfileSetting>;
+
+export default function LoginProfileSetting({
+  userInfo,
+  redirectTo,
+}: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm<ProfileSettingType>({
+    resolver: standardSchemaResolver(ProfileSetting),
+    defaultValues: {
+      nickname: userInfo.nickname,
+    },
+  });
+  const router = useRouter();
+  const { mutate: updateUserProfileMutation, isPending } = useMutation({
+    mutationFn: updateUserProfile,
+    onSuccess: () => {
+      router.replace(redirectTo ?? "/");
+    },
+    onError: (error: AxiosError) => {
+      errorToast({
+        title: "닉네임 변경에 실패했습니다.",
+        description:
+          (error.response?.data as { message: string }).message ??
+          "서버 오류가 발생했습니다.",
+      });
+    },
+  });
+
+  const onSubmit = (data: ProfileSettingType) => {
+    updateUserProfileMutation(data.nickname);
+  };
+
+  return (
+    <>
+      <Head>
+        <title>꼬꼬면 면접</title>
+        <meta
+          name="description"
+          content="운영체제, 데이터베이스, 자료구조, 알고리즘 면접 연습"
+        />
+        <link rel="icon" href="/favicon.ico" />
+        <link rel="preload" as="image" href="/interviewBg.jpg" />
+      </Head>
+      <Layout>
+        <Header user={userInfo} />
+        <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+          <div className="w-full max-w-md">
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+              <div className="text-center mb-8">
+                <h1 className="text-2xl font-semibold text-gray-900 mb-2">
+                  프로필 설정
+                </h1>
+                <p className="text-gray-600 text-sm">닉네임을 설정해주세요</p>
+              </div>
+
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                <div>
+                  <label
+                    htmlFor="nickname"
+                    className="block text-sm font-medium text-gray-700 mb-2"
+                  >
+                    닉네임
+                  </label>
+                  <Input
+                    {...register("nickname", { required: true })}
+                    type="text"
+                    className="w-full"
+                    role="textbox"
+                    placeholder="닉네임을 입력해주세요"
+                    onChange={(e) => setValue("nickname", e.target.value)}
+                  />
+                  {errors.nickname && (
+                    <p className="mt-2 text-sm text-red-600">
+                      {errors.nickname.message}
+                    </p>
+                  )}
+                </div>
+                <Button
+                  type="submit"
+                  variant="primary"
+                  className="w-full"
+                  disabled={isPending}
+                  aria-disabled={isPending}
+                >
+                  저장하기
+                </Button>
+              </form>
+            </div>
+          </div>
+        </main>
+      </Layout>
+    </>
+  );
+}
+
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext
+): Promise<GetServerSidePropsResult<LoginProfileSettingProps>> => {
+  return withCheckInServer<LoginProfileSettingProps>(async () => {
+    const userInfo = await getUserInfo(context);
+    if (userInfo.data.profile_completed) {
+      return {
+        redirect: {
+          destination: (context.query.redirectTo as string) ?? "/",
+          permanent: false,
+        },
+      };
+    }
+
+    return {
+      data: {
+        userInfo: userInfo.data,
+        redirectTo: (context.query.redirectTo as string) ?? "/",
+      },
+    };
+  });
+};

--- a/apps/client/src/pages/login/profile.tsx
+++ b/apps/client/src/pages/login/profile.tsx
@@ -1,4 +1,4 @@
-import { getUserInfo, updateUserProfile } from "@/domains/auth/api";
+import { getUserInfo } from "@/domains/auth/api";
 import { User } from "@/domains/auth/types";
 import { withCheckInServer } from "@/utils/auth";
 import {
@@ -10,67 +10,17 @@ import Head from "next/head";
 import { JSX } from "react";
 import { Layout } from "@/components/layout";
 import Header from "@/shared/header";
-import { Input } from "@kokomen/ui/components/input";
-import { z } from "zod";
-import { useForm } from "react-hook-form";
-import { Button } from "@kokomen/ui/components/button";
-import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
-import { useMutation } from "@tanstack/react-query";
-import { useRouter } from "next/router";
-import { errorToast } from "@kokomen/ui/hooks/useToast";
-import { AxiosError } from "axios";
+import ProfileSettingForm from "@/domains/auth/components/profilesettingForm";
 
 interface LoginProfileSettingProps {
   userInfo: User;
   redirectTo: string;
 }
-// eslint-disable-next-line @rushstack/typedef-var
-const ProfileSetting = z.object({
-  nickname: z
-    .string()
-    .min(3, { message: "닉네임은 3자 이상이어야 합니다." })
-    .max(20, { message: "닉네임은 20자 이하이어야 합니다." })
-    .regex(/^[가-힣a-zA-Z0-9]+$/, {
-      message: "닉네임은 한글 조합, 영문, 숫자만 사용할 수 있습니다.",
-    }),
-});
-type ProfileSettingType = z.infer<typeof ProfileSetting>;
 
 export default function LoginProfileSetting({
   userInfo,
   redirectTo,
 }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    setValue,
-  } = useForm<ProfileSettingType>({
-    resolver: standardSchemaResolver(ProfileSetting),
-    defaultValues: {
-      nickname: userInfo.nickname,
-    },
-  });
-  const router = useRouter();
-  const { mutate: updateUserProfileMutation, isPending } = useMutation({
-    mutationFn: updateUserProfile,
-    onSuccess: () => {
-      router.replace(redirectTo ?? "/");
-    },
-    onError: (error: AxiosError) => {
-      errorToast({
-        title: "닉네임 변경에 실패했습니다.",
-        description:
-          (error.response?.data as { message: string }).message ??
-          "서버 오류가 발생했습니다.",
-      });
-    },
-  });
-
-  const onSubmit = (data: ProfileSettingType) => {
-    updateUserProfileMutation(data.nickname);
-  };
-
   return (
     <>
       <Head>
@@ -94,38 +44,7 @@ export default function LoginProfileSetting({
                 <p className="text-gray-600 text-sm">닉네임을 설정해주세요</p>
               </div>
 
-              <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-                <div>
-                  <label
-                    htmlFor="nickname"
-                    className="block text-sm font-medium text-gray-700 mb-2"
-                  >
-                    닉네임
-                  </label>
-                  <Input
-                    {...register("nickname", { required: true })}
-                    type="text"
-                    className="w-full"
-                    role="textbox"
-                    placeholder="닉네임을 입력해주세요"
-                    onChange={(e) => setValue("nickname", e.target.value)}
-                  />
-                  {errors.nickname && (
-                    <p className="mt-2 text-sm text-red-600">
-                      {errors.nickname.message}
-                    </p>
-                  )}
-                </div>
-                <Button
-                  type="submit"
-                  variant="primary"
-                  className="w-full"
-                  disabled={isPending}
-                  aria-disabled={isPending}
-                >
-                  저장하기
-                </Button>
-              </form>
+              <ProfileSettingForm userInfo={userInfo} redirectTo={redirectTo} />
             </div>
           </div>
         </main>

--- a/packages/ui/src/components/input/index.tsx
+++ b/packages/ui/src/components/input/index.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 type InputVariantProps = VariantProps<typeof inputVariants>;
 const inputVariants = cva(
-  "flex items-center rounded-md p-2 outline-border-input bg-gray- outline-2 hover:outline-primary-hover transition-all focus:outline-border-input-focus",
+  "flex items-center rounded-md p-2 outline-border-input bg-gray- outline-2 outline-primary-border hover:outline-primary-hover transition-all focus:outline-primary-active",
   {
     variants: {
       variant: {
@@ -35,7 +35,7 @@ interface InputProps
     InputVariantProps {
   ref?: React.Ref<HTMLInputElement>;
   children?: React.ReactNode;
-  name: string;
+  name?: string; // optional로 변경
 }
 export const Input = ({
   variant,
@@ -46,15 +46,12 @@ export const Input = ({
   name,
   ...props
 }: InputProps) => (
-  <label htmlFor={name}>
-    <input
-      dangerouslySetInnerHTML={undefined}
-      ref={ref}
-      type={type}
-      className={cn(inputVariants({ variant, size }), className)}
-      id={name}
-      {...props}
-    />
-    {props.children}
-  </label>
+  <input
+    dangerouslySetInnerHTML={undefined}
+    ref={ref}
+    type={type}
+    className={cn(inputVariants({ variant, size }), className)}
+    id={name}
+    {...props}
+  />
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,6 +1779,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hookform/resolvers@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@hookform/resolvers@npm:5.1.1"
+  dependencies:
+    "@standard-schema/utils": "npm:^0.3.0"
+  peerDependencies:
+    react-hook-form: ^7.55.0
+  checksum: 10c0/74601ba4abb3159bbaa25175af9459a2c0337a28d8c0a5be95c7ae7b0a76ddafcf63c03eea8561fd099fe80b226194ad09e3824c53b9beda38393ff9fd264a03
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.13.0":
   version: 0.13.0
   resolution: "@humanwhocodes/config-array@npm:0.13.0"
@@ -2446,6 +2457,7 @@ __metadata:
     "@babel/core": "npm:^7.27.4"
     "@babel/preset-env": "npm:^7.27.2"
     "@babel/preset-typescript": "npm:^7.27.1"
+    "@hookform/resolvers": "npm:^5.1.1"
     "@kokomen/eslint-config": "workspace:*"
     "@kokomen/ui": "workspace:*"
     "@lhci/cli": "npm:^0.15.0"
@@ -2482,6 +2494,7 @@ __metadata:
     three: "npm:^0.177.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5"
+    zod: "npm:^3.25.74"
   languageName: unknown
   linkType: soft
 
@@ -4133,6 +4146,13 @@ __metadata:
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
   checksum: 10c0/a707476efd523d2138ef6bba916c83c4a377a8372ef04fad87499458af9f01afc58f4f245c5fd062793d6d70587309330c6f96947b5bd5697961c18004dc3e26
+  languageName: node
+  linkType: hard
+
+"@standard-schema/utils@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@standard-schema/utils@npm:0.3.0"
+  checksum: 10c0/6eb74cd13e52d5fc74054df51e37d947ef53f3ab9e02c085665dcca3c38c60ece8d735cebbdf18fbb13c775fbcb9becb3f53109b0e092a63f0f7389ce0993fd0
   languageName: node
   linkType: hard
 
@@ -14998,6 +15018,13 @@ __metadata:
   version: 3.25.67
   resolution: "zod@npm:3.25.67"
   checksum: 10c0/80a0cab3033272c4ab9312198081f0c4ea88e9673c059aa36dc32024906363729db54bdb78f3dc9d5529bd1601f74974d5a56c0a23e40c6f04a9270c9ff22336
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.74":
+  version: 3.25.74
+  resolution: "zod@npm:3.25.74"
+  checksum: 10c0/59e38b046ac333b5bd1ba325a83b6798721227cbfb1e69dfc7159bd7824b904241ab923026edb714fafefec3624265ae374a70aee9a5a45b365bd31781ffa105
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📌 개요

사용자 닉네임 설정 페이지 기능 추가 PR입니다.

## ✅ 작업 내용

- [x] 기능 추가 : 사용자 닉네임 설정 페이지 추가
- [x] 리팩토링 : 기존의 `withCheckInServer` 함수가 axiosresponse를 반환 타입으로 받다보니 사용성이 떨어져 getServersideResult로 반환타입을 변경하고 개선 
- [x] 리팩토링 : 로그인 콜백 페이지에서 프로필 설정이 안돼있을 경우 닉네임 설정으로 이동
- [x] 기능 추가 : 닉네임 설정 유효성 검사

## 🧪 테스트

- [x] 직접 테스트 완료
- [x] 테스트 코드 추가됨

## 📝 참고 사항

- 없음

## 📎 관련 이슈

FEATURE - #30 
