### PR TITLE
[Feat/#32] - SpeechRecognition을 활용한 음성 인식 추가

### DIFF
--- a/apps/client/__tests__/profileSetting.test.tsx
+++ b/apps/client/__tests__/profileSetting.test.tsx
@@ -23,11 +23,7 @@ describe("profile setting 페이지 이동 테스트", () => {
     );
     renderWithProviders(<KakaoCallbackPage code="1234567890" state="test" />);
     await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith("/login/profile", {
-        query: {
-          redirectTo: "test",
-        },
-      });
+      expect(mockReplace).toHaveBeenCalledWith("/login/profile?state=test");
     });
   });
 });
@@ -36,7 +32,7 @@ describe("profile setting 렌더링 테스트", () => {
   it("프로필 설정 페이지에서 제대로 유저 기본 필드값이 렌더링되는지 확인", async () => {
     renderWithProviders(
       <LoginProfileSetting
-        redirectTo="/"
+        state="/"
         userInfo={{
           id: 1,
           nickname: "오상훈",
@@ -65,7 +61,7 @@ describe("profile setting 기능 테스트", () => {
     );
     renderWithProviders(
       <LoginProfileSetting
-        redirectTo="/"
+        state="/"
         userInfo={{
           id: 1,
           nickname: "오상훈",
@@ -99,7 +95,7 @@ describe("profile setting 기능 테스트", () => {
     );
     renderWithProviders(
       <LoginProfileSetting
-        redirectTo="/"
+        state="/"
         userInfo={{
           id: 1,
           nickname: "오상훈",
@@ -125,7 +121,7 @@ describe("profile setting 기능 테스트", () => {
   it("프로필 설정 페이지에서 유효하지 않은 값을 입력했을 때 닉네임  실패 테스트", async () => {
     renderWithProviders(
       <LoginProfileSetting
-        redirectTo="/"
+        state="/"
         userInfo={{
           id: 1,
           nickname: "오상훈",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -44,6 +44,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
+    "@types/dom-speech-recognition": "^0.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/apps/client/src/hooks/useSpeechRecognition.ts
+++ b/apps/client/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseSpeechRecognitionOptions {
+  lang?: string;
+  continuous?: boolean;
+  interimResults?: boolean;
+  maxAlternatives?: number;
+}
+
+interface UseSpeechRecognitionReturn {
+  isListening: boolean;
+  isSupported: boolean;
+  startListening: () => void;
+  stopListening: () => void;
+  error: string | null;
+}
+type SpeechRecognitionType =
+  | typeof window.SpeechRecognition
+  | typeof window.webkitSpeechRecognition;
+
+interface UseSpeechRecognitionProps {
+  // eslint-disable-next-line no-unused-vars
+  onSpeechEnd: (result: string) => void;
+  options?: UseSpeechRecognitionOptions;
+}
+export const useSpeechRecognition = ({
+  onSpeechEnd,
+  options = {},
+}: UseSpeechRecognitionProps): UseSpeechRecognitionReturn => {
+  const {
+    lang = "ko-KR",
+    continuous = true,
+    interimResults = false,
+    maxAlternatives = 1,
+  } = options;
+
+  const [isListening, setIsListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSupported, setIsSupported] = useState(false);
+
+  const recognitionRef = useRef<InstanceType<SpeechRecognitionType> | null>(
+    null
+  );
+
+  useEffect(() => {
+    // 브라우저 지원 확인
+    const SpeechRecognition =
+      window.SpeechRecognition || window.webkitSpeechRecognition;
+
+    if (!SpeechRecognition) {
+      setIsSupported(false);
+      setError("이 브라우저는 음성 인식을 지원하지 않습니다.");
+      return;
+    }
+
+    setIsSupported(true);
+
+    // SpeechRecognition 인스턴스 생성
+    const recognition = new SpeechRecognition();
+    recognitionRef.current = recognition;
+
+    // 설정
+    recognition.lang = lang;
+    recognition.continuous = continuous;
+    recognition.interimResults = interimResults;
+    recognition.maxAlternatives = maxAlternatives;
+
+    // 이벤트 핸들러
+    recognition.onstart = () => {
+      setIsListening(true);
+      setError(null);
+    };
+
+    recognition.onresult = (event) => {
+      let finalTranscript = "";
+      let interimTranscript = "";
+
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript;
+        if (event.results[i].isFinal) {
+          finalTranscript += transcript;
+        } else {
+          interimTranscript += transcript;
+        }
+      }
+      onSpeechEnd(finalTranscript + interimTranscript);
+    };
+
+    recognition.onerror = (event) => {
+      setIsListening(false);
+      let errorMessage = "음성 인식 중 오류가 발생했습니다.";
+
+      switch (event.error) {
+        case "no-speech":
+          errorMessage = "음성이 감지되지 않았습니다.";
+          break;
+        case "audio-capture":
+          errorMessage = "마이크에 접근할 수 없습니다.";
+          break;
+        case "not-allowed":
+          errorMessage = "마이크 권한이 필요합니다.";
+          break;
+        case "network":
+          errorMessage = "네트워크 오류가 발생했습니다.";
+          break;
+        default:
+          errorMessage = `음성 인식 오류: ${event.error}`;
+      }
+
+      setError(errorMessage);
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+    };
+
+    return () => {
+      if (recognition) {
+        recognition.abort();
+      }
+    };
+  }, [lang, continuous, interimResults, maxAlternatives, onSpeechEnd]);
+
+  const startListening = useCallback(() => {
+    if (!isSupported || !recognitionRef.current) {
+      setError("음성 인식이 지원되지 않습니다.");
+      return;
+    }
+
+    try {
+      recognitionRef.current?.start();
+    } catch (error) {
+      setError("음성 인식을 시작할 수 없습니다.");
+    }
+  }, [isSupported]);
+
+  const stopListening = useCallback(() => {
+    if (recognitionRef.current && isListening) {
+      recognitionRef.current?.stop();
+    }
+  }, [isListening]);
+
+  return {
+    isListening,
+    isSupported,
+    startListening,
+    stopListening,
+    error,
+  };
+};

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -20,7 +20,7 @@
       "@/*": ["./src/*", "../../packages/ui/src/*"],
       "@kokomen/ui/*": ["../../packages/ui/src/*"]
     },
-    "types": ["jest", "@testing-library/jest-dom"]
+    "types": ["jest", "@testing-library/jest-dom", "dom-speech-recognition"]
   },
   "include": [
     "next-env.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,6 +2472,7 @@ __metadata:
     "@testing-library/react": "npm:^16.3.0"
     "@types/babel__core": "npm:^7"
     "@types/babel__preset-env": "npm:^7"
+    "@types/dom-speech-recognition": "npm:^0.0.6"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^20"
     "@types/react": "npm:^19"
@@ -4939,6 +4940,13 @@ __metadata:
   version: 0.0.9
   resolution: "@types/doctrine@npm:0.0.9"
   checksum: 10c0/cdaca493f13c321cf0cacd1973efc0ae74569633145d9e6fc1128f32217a6968c33bea1f858275239fe90c98f3be57ec8f452b416a9ff48b8e8c1098b20fa51c
+  languageName: node
+  linkType: hard
+
+"@types/dom-speech-recognition@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@types/dom-speech-recognition@npm:0.0.6"
+  checksum: 10c0/2483e59689b62c5be1d5da5168ee49be933d91e6866d5f60978b31aaf1f254d921c67f4c795c14a90442b0f86d51496cec88d26c810cf6e3124db1880f798c13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📌 개요

텍스트 모드 내에서도 음성 인식 기능을 활용하기 위해 버튼을 추가하여 사용할 수 있도록 하였습니다.

<img width="1091" alt="스크린샷 2025-07-07 오후 10 19 02" src="https://github.com/user-attachments/assets/807e7702-673a-4706-b227-e3802e6d1f39" />

<img width="1096" alt="스크린샷 2025-07-07 오후 10 19 21" src="https://github.com/user-attachments/assets/4977721e-e283-4f07-aff9-fbe1f843922a" />

- 버튼을 누르면 중지를 통해 다시 기존의 음성 인식을 off할 수 있습니다.
- 음성 인식 중에는 문단이 얼추 끝날 때마다 텍스트가 추가됩니다.
- SpeechRecognition의 `interimResults` 기능을 추가하면 중간중간 바로 텍스트 인식값을 받을 수 있지만 기존의 값을 지우거나 덮어쓰는 문제가 있어 false로 설정하였습니다. 해당 문제는 추후 보완 예정입니다.

## ✅ 작업 내용

- [x] SpeechRecognition을 활용한 음성 인식 추가
- [x] 리팩토링: 테스트 중 기존에 login callback query parameter 바꾸지 않은 실패 테스트 개선

## 🧪 테스트

- [x] 직접 테스트 완료
- [x] 테스트 코드 추가됨

## 📝 참고 사항

- 없음

## 📎 관련 이슈

Closes #32