### PR TITLE
[Feat/#38] - 회원 면접 결과 열람 및 회원 조회 기능 추가

### DIFF
--- a/apps/client/__tests__/memberInterviewPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewPage.test.tsx
@@ -31,6 +31,7 @@ const mockMemberInterview: CamelCasedProperties<MemberInterview> = {
   intervieweeNickname: "test",
   totalMemberCount: 0,
   intervieweeRank: 0,
+  totalPageCount: 1,
 };
 
 describe("memberInterviewPage", () => {
@@ -83,6 +84,27 @@ describe("memberInterviewPage", () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith("/members/1?sort=desc&page=1");
     });
+  });
+  it("데이터 페이지네이션 테스트", async () => {
+    renderWithProviders(
+      <MemberInterviewPage
+        memberId="1"
+        user={null}
+        interviews={{
+          ...mockMemberInterview,
+          totalPageCount: 1,
+        }}
+        sort="desc"
+        page={1}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText("테스트1")).toBeInTheDocument();
+      expect(screen.getByText("테스트2")).toBeInTheDocument();
+    });
+
+    const nextButton = screen.getByRole("button", { name: "next page" });
+    expect(nextButton).toBeDisabled();
   });
 
   it("면접 기록 데이터 없을 때 렌더링 테스트", async () => {

--- a/apps/client/__tests__/memberInterviewPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewPage.test.tsx
@@ -1,0 +1,137 @@
+import { server } from "@/mocks";
+import MemberInterviewPage from "@/pages/members/[memberId]";
+import { renderWithProviders } from "@/utils/test-utils";
+import { fireEvent, screen, waitFor } from "@testing-library/dom";
+import { http, HttpResponse } from "msw";
+
+describe("memberInterviewPage", () => {
+  it("렌더링 기본 테스트", async () => {
+    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
+    await waitFor(() => {
+      expect(screen.getByText("면접 기록")).toBeInTheDocument();
+    });
+  });
+  it("데이터 페칭에 따른 렌더링 테스트", async () => {
+    server.use(
+      http.get(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=0&size=10&sort=id,desc`,
+        async () => {
+          return HttpResponse.json([
+            {
+              interview_id: 1,
+              interview_state: "FINISHED",
+              interview_category: "테스트1",
+              created_at: "2021-01-01",
+              root_question: "면접 질문",
+            },
+            {
+              interview_id: 2,
+              interview_state: "FINISHED",
+              interview_category: "테스트2",
+              created_at: "2021-01-01",
+              root_question: "면접 질문",
+            },
+          ]);
+        }
+      )
+    );
+    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
+    await waitFor(() => {
+      expect(screen.getByText("테스트1")).toBeInTheDocument();
+      expect(screen.getByText("테스트2")).toBeInTheDocument();
+    });
+  });
+  it("데이터 페이지네이션 테스트", async () => {
+    server.use(
+      http.get(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=0&size=10&sort=id,desc`,
+        async () => {
+          return HttpResponse.json([
+            {
+              interview_id: 1,
+              interview_state: "FINISHED",
+              interview_category: "테스트1",
+              created_at: "2021-01-01",
+              root_question: "면접 질문",
+            },
+            {
+              interview_id: 2,
+              interview_state: "FINISHED",
+              interview_category: "테스트2",
+              created_at: "2021-01-01",
+              root_question: "면접 질문",
+            },
+          ]);
+        },
+        { once: true }
+      )
+    );
+    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
+    await waitFor(() => {
+      expect(screen.getByText("테스트1")).toBeInTheDocument();
+      expect(screen.getByText("테스트2")).toBeInTheDocument();
+    });
+    server.use(
+      http.get(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=1&size=10&sort=id,desc`,
+        async () => {
+          return HttpResponse.json([
+            {
+              interview_id: 1,
+              interview_state: "FINISHED",
+              interview_category: "테스트3",
+              created_at: "2021-01-01",
+              root_question: "면접 질문",
+            },
+            {
+              interview_id: 2,
+              interview_state: "FINISHED",
+              interview_category: "테스트4",
+              created_at: "2021-01-01",
+              root_question: "면접 질문",
+            },
+          ]);
+        }
+      )
+    );
+    const nextButton = screen.getByRole("button", { name: "next page" });
+    fireEvent.click(nextButton);
+    await waitFor(() => {
+      expect(screen.getByText("테스트3")).toBeInTheDocument();
+      expect(screen.getByText("테스트4")).toBeInTheDocument();
+    });
+  });
+
+  it("면접 기록 데이터 없을 때 렌더링 테스트", async () => {
+    server.use(
+      http.get(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=0&size=10&sort=id,desc`,
+        async () => {
+          return HttpResponse.json([]);
+        }
+      )
+    );
+    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
+    await waitFor(() => {
+      expect(
+        screen.getByText("해당 유저의 면접 기록이 없습니다")
+      ).toBeInTheDocument();
+    });
+  });
+  it("면접 기록 데이터 에러 테스트", async () => {
+    server.use(
+      http.get(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=0&size=10&sort=id,desc`,
+        async () => {
+          return HttpResponse.error();
+        }
+      )
+    );
+    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
+    await waitFor(() => {
+      expect(
+        screen.getByText("데이터를 불러오는 중 오류가 발생했습니다.")
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/client/__tests__/memberInterviewPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewPage.test.tsx
@@ -16,6 +16,7 @@ const mockMemberInterview: CamelCasedProperties<MemberInterview> = {
       score: 20,
       interviewLikeCount: 10,
       interviewAlreadyLiked: false,
+      interviewViewCount: 10,
     },
     {
       interviewId: 2,
@@ -26,6 +27,7 @@ const mockMemberInterview: CamelCasedProperties<MemberInterview> = {
       score: 20,
       interviewLikeCount: 10,
       interviewAlreadyLiked: false,
+      interviewViewCount: 10,
     },
   ],
   intervieweeNickname: "test",

--- a/apps/client/__tests__/memberInterviewPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewPage.test.tsx
@@ -71,7 +71,7 @@ describe("memberInterviewPage", () => {
         user={null}
         interviews={mockMemberInterview}
         sort="desc"
-        page={0}
+        page={1}
       />
     );
     await waitFor(() => {
@@ -82,7 +82,7 @@ describe("memberInterviewPage", () => {
     const nextButton = screen.getByRole("button", { name: "next page" });
     fireEvent.click(nextButton);
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith("/members/1?sort=desc&page=1");
+      expect(mockPush).toHaveBeenCalledWith("/members/1?sort=desc&page=2");
     });
   });
   it("데이터 페이지네이션 테스트", async () => {
@@ -92,7 +92,7 @@ describe("memberInterviewPage", () => {
         user={null}
         interviews={{
           ...mockMemberInterview,
-          totalPageCount: 1,
+          totalPageCount: 2,
         }}
         sort="desc"
         page={1}

--- a/apps/client/__tests__/memberInterviewPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewPage.test.tsx
@@ -1,136 +1,103 @@
-import { server } from "@/mocks";
+import { MemberInterview } from "@/domains/members/types";
 import MemberInterviewPage from "@/pages/members/[memberId]";
+import { CamelCasedProperties } from "@/utils/convertConvention";
 import { renderWithProviders } from "@/utils/test-utils";
 import { fireEvent, screen, waitFor } from "@testing-library/dom";
-import { http, HttpResponse } from "msw";
+import { mockPush } from "jest.setup";
+
+const mockMemberInterview: CamelCasedProperties<MemberInterview> = {
+  interviewSummaries: [
+    {
+      interviewId: 1,
+      interviewCategory: "테스트1",
+      createdAt: "2021-01-01",
+      rootQuestion: "면접 질문",
+      maxQuestionCount: 10,
+      score: 20,
+      interviewLikeCount: 10,
+      interviewAlreadyLiked: false,
+    },
+    {
+      interviewId: 2,
+      interviewCategory: "테스트2",
+      createdAt: "2021-01-01",
+      rootQuestion: "면접 질문",
+      maxQuestionCount: 10,
+      score: 20,
+      interviewLikeCount: 10,
+      interviewAlreadyLiked: false,
+    },
+  ],
+  intervieweeNickname: "test",
+  totalMemberCount: 0,
+  intervieweeRank: 0,
+};
 
 describe("memberInterviewPage", () => {
   it("렌더링 기본 테스트", async () => {
-    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
+    renderWithProviders(
+      <MemberInterviewPage
+        memberId="1"
+        user={null}
+        interviews={mockMemberInterview}
+        sort="desc"
+        page={0}
+      />
+    );
     await waitFor(() => {
       expect(screen.getByText("면접 기록")).toBeInTheDocument();
     });
   });
   it("데이터 페칭에 따른 렌더링 테스트", async () => {
-    server.use(
-      http.get(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=0&size=10&sort=id,desc`,
-        async () => {
-          return HttpResponse.json([
-            {
-              interview_id: 1,
-              interview_state: "FINISHED",
-              interview_category: "테스트1",
-              created_at: "2021-01-01",
-              root_question: "면접 질문",
-            },
-            {
-              interview_id: 2,
-              interview_state: "FINISHED",
-              interview_category: "테스트2",
-              created_at: "2021-01-01",
-              root_question: "면접 질문",
-            },
-          ]);
-        }
-      )
+    renderWithProviders(
+      <MemberInterviewPage
+        memberId="1"
+        user={null}
+        interviews={mockMemberInterview}
+        sort="desc"
+        page={0}
+      />
     );
-    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
     await waitFor(() => {
       expect(screen.getByText("테스트1")).toBeInTheDocument();
       expect(screen.getByText("테스트2")).toBeInTheDocument();
     });
   });
   it("데이터 페이지네이션 테스트", async () => {
-    server.use(
-      http.get(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=0&size=10&sort=id,desc`,
-        async () => {
-          return HttpResponse.json([
-            {
-              interview_id: 1,
-              interview_state: "FINISHED",
-              interview_category: "테스트1",
-              created_at: "2021-01-01",
-              root_question: "면접 질문",
-            },
-            {
-              interview_id: 2,
-              interview_state: "FINISHED",
-              interview_category: "테스트2",
-              created_at: "2021-01-01",
-              root_question: "면접 질문",
-            },
-          ]);
-        },
-        { once: true }
-      )
+    renderWithProviders(
+      <MemberInterviewPage
+        memberId="1"
+        user={null}
+        interviews={mockMemberInterview}
+        sort="desc"
+        page={0}
+      />
     );
-    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
     await waitFor(() => {
       expect(screen.getByText("테스트1")).toBeInTheDocument();
       expect(screen.getByText("테스트2")).toBeInTheDocument();
     });
-    server.use(
-      http.get(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=1&size=10&sort=id,desc`,
-        async () => {
-          return HttpResponse.json([
-            {
-              interview_id: 1,
-              interview_state: "FINISHED",
-              interview_category: "테스트3",
-              created_at: "2021-01-01",
-              root_question: "면접 질문",
-            },
-            {
-              interview_id: 2,
-              interview_state: "FINISHED",
-              interview_category: "테스트4",
-              created_at: "2021-01-01",
-              root_question: "면접 질문",
-            },
-          ]);
-        }
-      )
-    );
+
     const nextButton = screen.getByRole("button", { name: "next page" });
     fireEvent.click(nextButton);
     await waitFor(() => {
-      expect(screen.getByText("테스트3")).toBeInTheDocument();
-      expect(screen.getByText("테스트4")).toBeInTheDocument();
+      expect(mockPush).toHaveBeenCalledWith("/members/1?sort=desc&page=1");
     });
   });
 
   it("면접 기록 데이터 없을 때 렌더링 테스트", async () => {
-    server.use(
-      http.get(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=0&size=10&sort=id,desc`,
-        async () => {
-          return HttpResponse.json([]);
-        }
-      )
+    renderWithProviders(
+      <MemberInterviewPage
+        memberId="1"
+        user={null}
+        interviews={{ ...mockMemberInterview, interviewSummaries: [] }}
+        sort="desc"
+        page={0}
+      />
     );
-    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
     await waitFor(() => {
       expect(
         screen.getByText("해당 유저의 면접 기록이 없습니다")
-      ).toBeInTheDocument();
-    });
-  });
-  it("면접 기록 데이터 에러 테스트", async () => {
-    server.use(
-      http.get(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews?member_id=1&page=0&size=10&sort=id,desc`,
-        async () => {
-          return HttpResponse.error();
-        }
-      )
-    );
-    renderWithProviders(<MemberInterviewPage memberId="1" user={null} />);
-    await waitFor(() => {
-      expect(
-        screen.getByText("데이터를 불러오는 중 오류가 발생했습니다.")
       ).toBeInTheDocument();
     });
   });

--- a/apps/client/__tests__/memberInterviewResultPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewResultPage.test.tsx
@@ -1,0 +1,139 @@
+import { renderWithProviders } from "@/utils/test-utils";
+import MemberInterviewResultPage from "@/pages/members/[memberId]/interviews/[interviewId]";
+import { mapToMemberInterviewResult } from "@/domains/members/types";
+import { fireEvent, screen, waitFor } from "@testing-library/dom";
+import { server } from "@/mocks";
+import { http, HttpResponse } from "msw";
+
+const memberInterviewResultData = {
+  feedbacks: [
+    {
+      question_id: 1,
+      answer_id: 1,
+      question: "자기소개를 해주세요.",
+      answer:
+        "안녕하세요. 저는 3년차 프론트엔드 개발자입니다. React와 TypeScript를 주로 사용하며, 사용자 경험을 중시하는 개발자입니다.",
+      answer_rank: "A",
+      answer_feedback:
+        "명확하고 간결한 자기소개로 좋은 첫인상을 주었습니다. 기술 스택과 개발 철학을 잘 어필했습니다.",
+      answer_like_count: 15,
+      answer_already_liked: false,
+    },
+  ],
+  total_feedback:
+    "전반적으로 기술적 역량과 협업 능력이 균형있게 발달한 개발자로 보입니다. 구체적인 경험과 성과를 바탕으로 답변하여 신뢰도가 높습니다. 향후 더 큰 규모의 프로젝트에서 리더십을 발휘할 수 있을 것으로 기대됩니다.",
+  total_score: 85,
+  interview_like_count: 23,
+  interview_already_liked: false,
+};
+
+describe("면접 결과 페이지 테스트", () => {
+  it("면접 결과 페이지 렌더링 테스트", async () => {
+    renderWithProviders(
+      <MemberInterviewResultPage
+        interviewId={1}
+        result={mapToMemberInterviewResult(memberInterviewResultData)}
+        user={null}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+  });
+  it("면접 좋아요 버튼 클릭 테스트", async () => {
+    renderWithProviders(
+      <MemberInterviewResultPage
+        interviewId={1}
+        result={mapToMemberInterviewResult(memberInterviewResultData)}
+        user={null}
+      />
+    );
+    //좋아요 안 눌렀을 경우
+    server.use(
+      http.post(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews/1/like`,
+        () => {
+          return HttpResponse.json({
+            message: "좋아요 성공",
+          });
+        }
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+    const interviewLikeButton = screen.getByRole("button", {
+      name: "전체 인터뷰 좋아요",
+    });
+    console.log(interviewLikeButton);
+    fireEvent.click(interviewLikeButton);
+    await waitFor(() => {
+      expect(interviewLikeButton).toHaveClass("bg-volcano-3 text-volcano-6");
+    });
+    //좋아요 눌렀을 경우
+    server.use(
+      http.delete(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/interviews/1/like`,
+        async () => {
+          return HttpResponse.json({
+            message: "좋아요 취소 성공",
+          });
+        }
+      )
+    );
+    screen.debug();
+    fireEvent.click(interviewLikeButton);
+    await waitFor(() => {
+      expect(interviewLikeButton).not.toHaveClass(
+        "bg-volcano-3 text-volcano-6"
+      );
+    });
+  });
+  it("질문 좋아요 버튼 클릭 테스트", async () => {
+    renderWithProviders(
+      <MemberInterviewResultPage
+        interviewId={1}
+        result={mapToMemberInterviewResult(memberInterviewResultData)}
+        user={null}
+      />
+    );
+    server.use(
+      http.post(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/answers/1/like`,
+        async () => {
+          return HttpResponse.json({
+            message: "좋아요 성공",
+          });
+        }
+      )
+    );
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+    //좋아요 안 눌렀을 경우
+    const answerLikeButton = screen.getByRole("button", {
+      name: "답변 1 좋아요",
+    });
+    fireEvent.click(answerLikeButton);
+    await waitFor(() => {
+      expect(answerLikeButton).toHaveClass("bg-volcano-3 text-volcano-6");
+    });
+
+    //좋아요 눌렀을 경우
+    server.use(
+      http.delete(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/answers/1/like`,
+        () => {
+          return HttpResponse.json({
+            message: "좋아요 취소 성공",
+          });
+        }
+      )
+    );
+    fireEvent.click(answerLikeButton);
+    await waitFor(() => {
+      expect(answerLikeButton).not.toHaveClass("bg-volcano-3 text-volcano-6");
+    });
+  });
+});

--- a/apps/client/__tests__/memberInterviewResultPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewResultPage.test.tsx
@@ -3,7 +3,11 @@ import MemberInterviewResultPage from "@/pages/members/[memberId]/interviews/[in
 import { fireEvent, screen, waitFor } from "@testing-library/dom";
 import { server } from "@/mocks";
 import { http, HttpResponse } from "msw";
-import { mapToCamelCase } from "@/utils/convertConvention";
+import {
+  CamelCasedProperties,
+  mapToCamelCase,
+} from "@/utils/convertConvention";
+import { MemberInterviewResult } from "@/domains/members/types";
 
 const memberInterviewResultData = {
   feedbacks: [
@@ -32,7 +36,11 @@ describe("면접 결과 페이지 테스트", () => {
     renderWithProviders(
       <MemberInterviewResultPage
         interviewId={1}
-        result={mapToCamelCase(memberInterviewResultData)}
+        result={
+          mapToCamelCase(
+            memberInterviewResultData
+          ) as CamelCasedProperties<MemberInterviewResult>
+        }
         user={null}
       />
     );
@@ -44,7 +52,11 @@ describe("면접 결과 페이지 테스트", () => {
     renderWithProviders(
       <MemberInterviewResultPage
         interviewId={1}
-        result={mapToCamelCase(memberInterviewResultData)}
+        result={
+          mapToCamelCase(
+            memberInterviewResultData
+          ) as CamelCasedProperties<MemberInterviewResult>
+        }
         user={null}
       />
     );
@@ -92,7 +104,11 @@ describe("면접 결과 페이지 테스트", () => {
     renderWithProviders(
       <MemberInterviewResultPage
         interviewId={1}
-        result={mapToCamelCase(memberInterviewResultData)}
+        result={
+          mapToCamelCase(
+            memberInterviewResultData
+          ) as CamelCasedProperties<MemberInterviewResult>
+        }
         user={null}
       />
     );

--- a/apps/client/__tests__/memberInterviewResultPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewResultPage.test.tsx
@@ -1,5 +1,5 @@
 import { renderWithProviders } from "@/utils/test-utils";
-import MemberInterviewResultPage from "@/pages/members/[memberId]/interviews/[interviewId]";
+import MemberInterviewResultPage from "@/pages/members/interviews/[interviewId]";
 import { fireEvent, screen, waitFor } from "@testing-library/dom";
 import { server } from "@/mocks";
 import { http, HttpResponse } from "msw";

--- a/apps/client/__tests__/memberInterviewResultPage.test.tsx
+++ b/apps/client/__tests__/memberInterviewResultPage.test.tsx
@@ -1,9 +1,9 @@
 import { renderWithProviders } from "@/utils/test-utils";
 import MemberInterviewResultPage from "@/pages/members/[memberId]/interviews/[interviewId]";
-import { mapToMemberInterviewResult } from "@/domains/members/types";
 import { fireEvent, screen, waitFor } from "@testing-library/dom";
 import { server } from "@/mocks";
 import { http, HttpResponse } from "msw";
+import { mapToCamelCase } from "@/utils/convertConvention";
 
 const memberInterviewResultData = {
   feedbacks: [
@@ -32,7 +32,7 @@ describe("면접 결과 페이지 테스트", () => {
     renderWithProviders(
       <MemberInterviewResultPage
         interviewId={1}
-        result={mapToMemberInterviewResult(memberInterviewResultData)}
+        result={mapToCamelCase(memberInterviewResultData)}
         user={null}
       />
     );
@@ -44,7 +44,7 @@ describe("면접 결과 페이지 테스트", () => {
     renderWithProviders(
       <MemberInterviewResultPage
         interviewId={1}
-        result={mapToMemberInterviewResult(memberInterviewResultData)}
+        result={mapToCamelCase(memberInterviewResultData)}
         user={null}
       />
     );
@@ -66,7 +66,6 @@ describe("면접 결과 페이지 테스트", () => {
     const interviewLikeButton = screen.getByRole("button", {
       name: "전체 인터뷰 좋아요",
     });
-    console.log(interviewLikeButton);
     fireEvent.click(interviewLikeButton);
     await waitFor(() => {
       expect(interviewLikeButton).toHaveClass("bg-volcano-3 text-volcano-6");
@@ -82,7 +81,6 @@ describe("면접 결과 페이지 테스트", () => {
         }
       )
     );
-    screen.debug();
     fireEvent.click(interviewLikeButton);
     await waitFor(() => {
       expect(interviewLikeButton).not.toHaveClass(
@@ -94,7 +92,7 @@ describe("면접 결과 페이지 테스트", () => {
     renderWithProviders(
       <MemberInterviewResultPage
         interviewId={1}
-        result={mapToMemberInterviewResult(memberInterviewResultData)}
+        result={mapToCamelCase(memberInterviewResultData)}
         user={null}
       />
     );

--- a/apps/client/__tests__/rank.test.tsx
+++ b/apps/client/__tests__/rank.test.tsx
@@ -51,7 +51,7 @@ describe("랭크 페이지 테스트", () => {
   it("랭크 페이지에서 각 랭커들을 눌렀을 때 랭커들의 페이지로 이동하는지 테스트", async () => {
     server.use(
       http.get(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/ranking`,
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/members/ranking?page=0&size=10`,
         async () => {
           return HttpResponse.json(mockRankList, { status: 200 });
         }

--- a/apps/client/src/domains/auth/types/index.ts
+++ b/apps/client/src/domains/auth/types/index.ts
@@ -4,6 +4,8 @@ interface User {
   score: number;
   token_count: number;
   profile_completed: boolean;
+  total_member_count: number;
+  rank: number;
 }
 
 export type { User };

--- a/apps/client/src/domains/dashboard/components/interviewHistory.tsx
+++ b/apps/client/src/domains/dashboard/components/interviewHistory.tsx
@@ -3,7 +3,7 @@ import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import { interviewHistoryKeys } from "@/utils/querykeys";
 import Select from "@kokomen/ui/components/select";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { Calendar, Clock, TrendingUp, Trophy } from "lucide-react";
+import { Calendar, Clock, Eye, Heart, TrendingUp, Trophy } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useRef, useState } from "react";
 
@@ -170,10 +170,22 @@ export default function InterviewHistory() {
                         {interview.score}점
                       </div>
                     )}
+                    {interview.interview_state === "FINISHED" && (
+                      <>
+                        <div className="flex items-center gap-1">
+                          <Eye className="w-4 h-4" />
+                          {interview.interview_view_count}
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <Heart className="w-4 h-4" />
+                          {interview.interview_like_count}
+                        </div>
+                      </>
+                    )}
                   </div>
                 </div>
 
-                <div className="md:ml-4 md:w-auto w-full">
+                <div className="md:ml-4 md:w-auto w-full flex flex-col gap-2">
                   <Link
                     href={
                       interview.interview_state === "FINISHED"
@@ -183,9 +195,17 @@ export default function InterviewHistory() {
                     className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-blue-600 bg-blue-50 hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
                   >
                     {interview.interview_state === "FINISHED"
-                      ? "결과 보기"
+                      ? "보고서 보기"
                       : "이어하기"}
                   </Link>
+                  {interview.interview_state === "FINISHED" && (
+                    <Link
+                      href={`/members/interviews/${interview.interview_id}`}
+                      className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-text-light-solid bg-gradient-primary hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
+                    >
+                      공개된 결과 보기
+                    </Link>
+                  )}
                 </div>
               </div>
             </div>

--- a/apps/client/src/domains/dashboard/types/index.ts
+++ b/apps/client/src/domains/dashboard/types/index.ts
@@ -7,6 +7,8 @@ type InterviewHistory = {
   max_question_count: number;
   cur_answer_count: number;
   score: number;
+  interview_view_count: number;
+  interview_like_count: number;
 };
 
 export type { InterviewHistory };

--- a/apps/client/src/domains/members/api/index.ts
+++ b/apps/client/src/domains/members/api/index.ts
@@ -1,9 +1,13 @@
 import {
+  mapToMemberInterviewResult,
   MemberInterview,
   Rank,
   TMemberInterviewResponse,
+  TMemberInterviewResult,
+  TMemberInterviewResultResponse,
 } from "@/domains/members/types";
 import axios, { AxiosInstance } from "axios";
+import { GetServerSidePropsContext } from "next";
 
 const memberInstance: AxiosInstance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}`,
@@ -30,4 +34,45 @@ const getMemberInterviews = async (
     .then((res) => res.data)
     .then((data) => data.map((interview) => new MemberInterview(interview)));
 
-export { getRankList, getMemberInterviews };
+const getMemberInterviewResult = async (
+  interviewId: number,
+  context: GetServerSidePropsContext
+): Promise<TMemberInterviewResult> =>
+  memberInstance
+    .get<TMemberInterviewResultResponse>(`/interviews/${interviewId}/result`, {
+      headers: {
+        cookie: context.req.headers.cookie,
+      },
+    })
+    .then((res) => res.data)
+    .then((data) => mapToMemberInterviewResult(data));
+
+const toggleMemberInterviewLike = async (
+  liked: boolean,
+  interviewId: number
+): Promise<void> => {
+  if (liked) {
+    return memberInstance.delete(`/interviews/${interviewId}/like`);
+  } else {
+    return memberInstance.post(`/interviews/${interviewId}/like`);
+  }
+};
+
+const toggleMemberInterviewAnswerLike = async (
+  liked: boolean,
+  answerId: number
+): Promise<void> => {
+  if (liked) {
+    return memberInstance.delete(`/answers/${answerId}/like`);
+  } else {
+    return memberInstance.post(`/answers/${answerId}/like`);
+  }
+};
+
+export {
+  getRankList,
+  getMemberInterviews,
+  getMemberInterviewResult,
+  toggleMemberInterviewLike,
+  toggleMemberInterviewAnswerLike,
+};

--- a/apps/client/src/domains/members/api/index.ts
+++ b/apps/client/src/domains/members/api/index.ts
@@ -1,16 +1,33 @@
-import { Rank } from "@/domains/members/types";
+import {
+  MemberInterview,
+  Rank,
+  TMemberInterviewResponse,
+} from "@/domains/members/types";
 import axios, { AxiosInstance } from "axios";
 
 const memberInstance: AxiosInstance = axios.create({
-  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}/members`,
+  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}`,
   withCredentials: true,
 });
 
 const getRankList = async (page = 0, size = 10): Promise<Rank[]> => {
-  const response = await memberInstance.get("/ranking", {
+  const response = await memberInstance.get("/members/ranking", {
     params: { page, size },
   });
   return response.data;
 };
 
-export { getRankList };
+const getMemberInterviews = async (
+  memberId: number,
+  page = 0,
+  sort = "desc",
+  size = 10
+): Promise<MemberInterview[]> =>
+  memberInstance
+    .get<TMemberInterviewResponse[]>("/interviews", {
+      params: { member_id: memberId, page, size, sort: `id,${sort}` },
+    })
+    .then((res) => res.data)
+    .then((data) => data.map((interview) => new MemberInterview(interview)));
+
+export { getRankList, getMemberInterviews };

--- a/apps/client/src/domains/members/api/index.ts
+++ b/apps/client/src/domains/members/api/index.ts
@@ -1,11 +1,12 @@
 import {
-  mapToMemberInterviewResult,
   MemberInterview,
+  MemberInterviewResult,
   Rank,
-  TMemberInterviewResponse,
-  TMemberInterviewResult,
-  TMemberInterviewResultResponse,
 } from "@/domains/members/types";
+import {
+  CamelCasedProperties,
+  mapToCamelCase,
+} from "@/utils/convertConvention";
 import axios, { AxiosInstance } from "axios";
 import { GetServerSidePropsContext } from "next";
 
@@ -14,7 +15,10 @@ const memberInstance: AxiosInstance = axios.create({
   withCredentials: true,
 });
 
-const getRankList = async (page = 0, size = 10): Promise<Rank[]> => {
+const getRankList = async (
+  page = 0,
+  size = 10
+): Promise<CamelCasedProperties<Rank>[]> => {
   const response = await memberInstance.get("/members/ranking", {
     params: { page, size },
   });
@@ -26,26 +30,26 @@ const getMemberInterviews = async (
   page = 0,
   sort = "desc",
   size = 10
-): Promise<MemberInterview[]> =>
+): Promise<CamelCasedProperties<MemberInterview>> =>
   memberInstance
-    .get<TMemberInterviewResponse[]>("/interviews", {
+    .get<MemberInterview>("/interviews", {
       params: { member_id: memberId, page, size, sort: `id,${sort}` },
     })
     .then((res) => res.data)
-    .then((data) => data.map((interview) => new MemberInterview(interview)));
+    .then(mapToCamelCase);
 
 const getMemberInterviewResult = async (
   interviewId: number,
   context: GetServerSidePropsContext
-): Promise<TMemberInterviewResult> =>
+): Promise<CamelCasedProperties<MemberInterviewResult>> =>
   memberInstance
-    .get<TMemberInterviewResultResponse>(`/interviews/${interviewId}/result`, {
+    .get<MemberInterviewResult>(`/interviews/${interviewId}/result`, {
       headers: {
         cookie: context.req.headers.cookie,
       },
     })
     .then((res) => res.data)
-    .then((data) => mapToMemberInterviewResult(data));
+    .then(mapToCamelCase);
 
 const toggleMemberInterviewLike = async (
   liked: boolean,

--- a/apps/client/src/domains/members/components/memberInterviewHistory.tsx
+++ b/apps/client/src/domains/members/components/memberInterviewHistory.tsx
@@ -3,6 +3,8 @@ import {
   Calendar,
   ChevronLeft,
   ChevronRight,
+  Eye,
+  Heart,
   TrendingUp,
   Trophy,
 } from "lucide-react";
@@ -13,6 +15,8 @@ import { MemberInterview } from "@/domains/members/types";
 import { CamelCasedProperties } from "@/utils/convertConvention";
 import { useRouter } from "next/router";
 import { formatDate } from "@/utils/date";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import { getVisiblePageNumbers } from "@/utils/pagination";
 
 export default function InterviewHistory({
   memberId,
@@ -28,6 +32,14 @@ export default function InterviewHistory({
   totalPageCount: number;
 }): JSX.Element {
   const router = useRouter();
+  const { isMobile } = useScreenSize();
+
+  const maxVisibleButtons = isMobile ? 3 : 5;
+  const visiblePageNumbers = getVisiblePageNumbers(
+    page,
+    totalPageCount,
+    maxVisibleButtons
+  );
 
   return (
     <>
@@ -79,12 +91,24 @@ export default function InterviewHistory({
                           {interview.score}점
                         </div>
                       )}
+                      <div className="flex items-center gap-1">
+                        <Eye className="w-4 h-4" />
+                        {interview.interviewViewCount}
+                      </div>
+                      <div
+                        className={`flex items-center gap-1 ${
+                          interview.interviewAlreadyLiked && "text-volcano-6"
+                        }`}
+                      >
+                        <Heart className="w-4 h-4" />
+                        {interview.interviewLikeCount}
+                      </div>
                     </div>
                   </div>
 
                   <div className="md:ml-4 md:w-auto w-full">
                     <Link
-                      href={`/members/${memberId}/interviews/${interview.interviewId}`}
+                      href={`/members/interviews/${interview.interviewId}`}
                       className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-blue-600 bg-blue-50 hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
                     >
                       인터뷰 조회하기
@@ -93,6 +117,7 @@ export default function InterviewHistory({
                 </div>
               </div>
             ))}
+            {/* 모바일: 3개, PC: 5개 버튼 표시 */}
             <div className="flex justify-center gap-2">
               <Button
                 type="button"
@@ -108,25 +133,27 @@ export default function InterviewHistory({
               >
                 <ChevronLeft />
               </Button>
-              {Array.from({ length: totalPageCount }).map((_, index) => (
+
+              {visiblePageNumbers.map((pageNumber) => (
                 <Button
-                  key={index}
+                  key={pageNumber}
                   type="button"
                   role="button"
-                  name={`${index + 1} page`}
+                  name={`${pageNumber + 1} page`}
                   aria-label="page"
-                  variant={page === index ? "primary" : "glass"}
-                  className={`${page === index && "disabled:opacity-100 disabled:bg-primary-bg-hover disabled:text-primary"}`}
+                  variant={page === pageNumber ? "primary" : "glass"}
+                  className={`${page === pageNumber && "disabled:opacity-100 disabled:bg-primary-bg-hover disabled:text-primary"}`}
                   onClick={() => {
                     router.push(
-                      `/members/${memberId}?sort=${sort}&page=${index}`
+                      `/members/${memberId}?sort=${sort}&page=${pageNumber}`
                     );
                   }}
-                  disabled={page === index}
+                  disabled={page === pageNumber}
                 >
-                  {index + 1}
+                  {pageNumber + 1}
                 </Button>
               ))}
+
               <Button
                 type="button"
                 role="button"

--- a/apps/client/src/domains/members/components/memberInterviewHistory.tsx
+++ b/apps/client/src/domains/members/components/memberInterviewHistory.tsx
@@ -132,7 +132,7 @@ export default function InterviewHistory({
                 role="button"
                 name="next page"
                 aria-label="next page"
-                disabled={page === totalPageCount}
+                disabled={page === totalPageCount - 1}
                 onClick={() => {
                   router.push(
                     `/members/${memberId}?sort=${sort}&page=${page + 1}`

--- a/apps/client/src/domains/members/components/memberInterviewHistory.tsx
+++ b/apps/client/src/domains/members/components/memberInterviewHistory.tsx
@@ -1,34 +1,31 @@
-import { getMemberInterviews } from "@/domains/members/api";
-import { memberKeys } from "@/utils/querykeys";
 import Select from "@kokomen/ui/components/select";
-import { useQuery } from "@tanstack/react-query";
 import {
   Calendar,
   ChevronLeft,
   ChevronRight,
-  Frown,
   TrendingUp,
   Trophy,
 } from "lucide-react";
 import Link from "next/link";
-import { JSX, useState } from "react";
+import { JSX } from "react";
 import { Button } from "@kokomen/ui/components/button";
+import { MemberInterview } from "@/domains/members/types";
+import { CamelCasedProperties } from "@/utils/convertConvention";
+import { useRouter } from "next/router";
+import { formatDate } from "@/utils/date";
 
 export default function InterviewHistory({
   memberId,
+  interviewSummaries,
+  sort,
+  page,
 }: {
   memberId: number;
+  interviewSummaries: CamelCasedProperties<MemberInterview>["interviewSummaries"];
+  sort: "desc" | "asc";
+  page: number;
 }): JSX.Element {
-  const [sort, setSort] = useState<"desc" | "asc">("desc");
-  const [page, setPage] = useState(0);
-  const {
-    data: interviews,
-    isLoading,
-    isError,
-  } = useQuery({
-    queryKey: memberKeys.interviewsByIdAndPage(memberId, sort, page),
-    queryFn: () => getMemberInterviews(memberId, page, sort),
-  });
+  const router = useRouter();
 
   return (
     <>
@@ -41,20 +38,18 @@ export default function InterviewHistory({
             { value: "desc", label: "최신순", disabled: false },
             { value: "asc", label: "오래된순", disabled: false },
           ]}
-          onChange={(value) => setSort(value as "desc" | "asc")}
+          onChange={(value) => {
+            router.push(`/members/${memberId}?sort=${value}&page=${page}`);
+          }}
         />
       </div>
 
-      {isLoading && <InterviewHistorySkeleton />}
+      {!interviewSummaries.length && <InterviewHistoryEmpty />}
 
-      {isError && <InterviewHistoryError />}
-
-      {!isLoading && interviews?.length === 0 && <InterviewHistoryEmpty />}
-
-      {(interviews?.length ?? 0) > 0 && (
+      {(interviewSummaries.length ?? 0) > 0 && (
         <div>
           <div className="space-y-4">
-            {interviews?.map((interview) => (
+            {interviewSummaries.map((interview) => (
               <div
                 key={interview.interviewId}
                 className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow"
@@ -74,7 +69,7 @@ export default function InterviewHistory({
                     <div className="flex items-center gap-6 text-sm text-gray-500">
                       <div className="flex items-center gap-1">
                         <Calendar className="w-4 h-4" />
-                        {interview.formattedCreatedDate}
+                        {formatDate(interview.createdAt)}
                       </div>
                       {interview.score && (
                         <div className="flex items-center gap-1">
@@ -102,7 +97,11 @@ export default function InterviewHistory({
                 role="button"
                 name="prev page"
                 aria-label="prev page"
-                onClick={() => setPage(page - 1)}
+                onClick={() => {
+                  router.push(
+                    `/members/${memberId}?sort=${sort}&page=${page === 0 ? 0 : page - 1}`
+                  );
+                }}
                 disabled={page === 0}
               >
                 <ChevronLeft />
@@ -112,7 +111,11 @@ export default function InterviewHistory({
                 role="button"
                 name="next page"
                 aria-label="next page"
-                onClick={() => setPage(page + 1)}
+                onClick={() => {
+                  router.push(
+                    `/members/${memberId}?sort=${sort}&page=${page + 1}`
+                  );
+                }}
               >
                 <ChevronRight />
               </Button>
@@ -124,47 +127,47 @@ export default function InterviewHistory({
   );
 }
 
-function InterviewHistorySkeleton(): JSX.Element {
-  return (
-    <div className="space-y-4">
-      {Array.from({ length: 10 }).map((_, index) => (
-        <div
-          key={index}
-          className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 animate-pulse"
-        >
-          <div className="flex items-start justify-between md:flex-row md:w-auto w-full flex-col gap-4">
-            <div className="flex-1">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="h-7 bg-gray-200 rounded-md w-32"></div>
-                <div className="h-6 bg-gray-200 rounded-full w-12"></div>
-              </div>
+// function InterviewHistorySkeleton(): JSX.Element {
+//   return (
+//     <div className="space-y-4">
+//       {Array.from({ length: 10 }).map((_, index) => (
+//         <div
+//           key={index}
+//           className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 animate-pulse"
+//         >
+//           <div className="flex items-start justify-between md:flex-row md:w-auto w-full flex-col gap-4">
+//             <div className="flex-1">
+//               <div className="flex items-center gap-3 mb-3">
+//                 <div className="h-7 bg-gray-200 rounded-md w-32"></div>
+//                 <div className="h-6 bg-gray-200 rounded-full w-12"></div>
+//               </div>
 
-              <div className="space-y-2 mb-4">
-                <div className="h-4 bg-gray-200 rounded w-full"></div>
-                <div className="h-4 bg-gray-200 rounded w-4/5"></div>
-              </div>
+//               <div className="space-y-2 mb-4">
+//                 <div className="h-4 bg-gray-200 rounded w-full"></div>
+//                 <div className="h-4 bg-gray-200 rounded w-4/5"></div>
+//               </div>
 
-              <div className="flex items-center gap-6 text-sm">
-                <div className="flex items-center gap-1">
-                  <div className="w-4 h-4 bg-gray-200 rounded"></div>
-                  <div className="h-4 bg-gray-200 rounded w-20"></div>
-                </div>
-                <div className="flex items-center gap-1">
-                  <div className="w-4 h-4 bg-gray-200 rounded"></div>
-                  <div className="h-4 bg-gray-200 rounded w-10"></div>
-                </div>
-              </div>
-            </div>
+//               <div className="flex items-center gap-6 text-sm">
+//                 <div className="flex items-center gap-1">
+//                   <div className="w-4 h-4 bg-gray-200 rounded"></div>
+//                   <div className="h-4 bg-gray-200 rounded w-20"></div>
+//                 </div>
+//                 <div className="flex items-center gap-1">
+//                   <div className="w-4 h-4 bg-gray-200 rounded"></div>
+//                   <div className="h-4 bg-gray-200 rounded w-10"></div>
+//                 </div>
+//               </div>
+//             </div>
 
-            <div className="md:ml-4 md:w-auto w-full">
-              <div className="h-9 bg-gray-200 rounded-md md:w-20 w-full"></div>
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
+//             <div className="md:ml-4 md:w-auto w-full">
+//               <div className="h-9 bg-gray-200 rounded-md md:w-20 w-full"></div>
+//             </div>
+//           </div>
+//         </div>
+//       ))}
+//     </div>
+//   );
+// }
 
 function InterviewHistoryEmpty(): JSX.Element {
   return (
@@ -177,11 +180,11 @@ function InterviewHistoryEmpty(): JSX.Element {
   );
 }
 
-function InterviewHistoryError(): JSX.Element {
-  return (
-    <div className="text-center py-12">
-      <Frown className="mx-auto h-12 w-12 text-volcano-5 mb-4" />
-      <p className="text-red-600">데이터를 불러오는 중 오류가 발생했습니다.</p>
-    </div>
-  );
-}
+// function InterviewHistoryError(): JSX.Element {
+//   return (
+//     <div className="text-center py-12">
+//       <Frown className="mx-auto h-12 w-12 text-volcano-5 mb-4" />
+//       <p className="text-red-600">데이터를 불러오는 중 오류가 발생했습니다.</p>
+//     </div>
+//   );
+// }

--- a/apps/client/src/domains/members/components/memberInterviewHistory.tsx
+++ b/apps/client/src/domains/members/components/memberInterviewHistory.tsx
@@ -19,11 +19,13 @@ export default function InterviewHistory({
   interviewSummaries,
   sort,
   page,
+  totalPageCount,
 }: {
   memberId: number;
   interviewSummaries: CamelCasedProperties<MemberInterview>["interviewSummaries"];
   sort: "desc" | "asc";
   page: number;
+  totalPageCount: number;
 }): JSX.Element {
   const router = useRouter();
 
@@ -39,7 +41,7 @@ export default function InterviewHistory({
             { value: "asc", label: "오래된순", disabled: false },
           ]}
           onChange={(value) => {
-            router.push(`/members/${memberId}?sort=${value}&page=${page}`);
+            router.push(`/members/${memberId}?sort=${value}&page=0`);
           }}
         />
       </div>
@@ -106,11 +108,31 @@ export default function InterviewHistory({
               >
                 <ChevronLeft />
               </Button>
+              {Array.from({ length: totalPageCount }).map((_, index) => (
+                <Button
+                  key={index}
+                  type="button"
+                  role="button"
+                  name={`${index + 1} page`}
+                  aria-label="page"
+                  variant={page === index ? "primary" : "glass"}
+                  className={`${page === index && "disabled:opacity-100 disabled:bg-primary-bg-hover disabled:text-primary"}`}
+                  onClick={() => {
+                    router.push(
+                      `/members/${memberId}?sort=${sort}&page=${index}`
+                    );
+                  }}
+                  disabled={page === index}
+                >
+                  {index + 1}
+                </Button>
+              ))}
               <Button
                 type="button"
                 role="button"
                 name="next page"
                 aria-label="next page"
+                disabled={page === totalPageCount}
                 onClick={() => {
                   router.push(
                     `/members/${memberId}?sort=${sort}&page=${page + 1}`

--- a/apps/client/src/domains/members/components/memberInterviewHistory.tsx
+++ b/apps/client/src/domains/members/components/memberInterviewHistory.tsx
@@ -87,7 +87,7 @@ export default function InterviewHistory({
 
                   <div className="md:ml-4 md:w-auto w-full">
                     <Link
-                      href={`/members/interviews/${interview.interviewId}`}
+                      href={`/members/${memberId}/interviews/${interview.interviewId}`}
                       className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-blue-600 bg-blue-50 hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
                     >
                       인터뷰 조회하기

--- a/apps/client/src/domains/members/components/memberQuestionFeedback.tsx
+++ b/apps/client/src/domains/members/components/memberQuestionFeedback.tsx
@@ -1,0 +1,135 @@
+import { TMemberInterviewResult } from "@/domains/members/types";
+import { useMutation } from "@tanstack/react-query";
+import { Heart } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useToast } from "@kokomen/ui/hooks/useToast";
+import { isAxiosError } from "axios";
+import { Button } from "@kokomen/ui/components/button";
+import { toggleMemberInterviewAnswerLike } from "@/domains/members/api";
+
+export default function MemberQuestionFeedback({
+  questionAndFeedback,
+  index,
+}: {
+  questionAndFeedback: TMemberInterviewResult["feedbacks"][number];
+  index: number;
+}) {
+  const [answerLiked, setAnswerLiked] = useState<boolean>(
+    questionAndFeedback.answerLiked
+  );
+  const { error: errorToast } = useToast();
+  const { mutate: toggleInterviewLikeMutation, isPending } = useMutation({
+    mutationFn: (liked: boolean) =>
+      toggleMemberInterviewAnswerLike(liked, questionAndFeedback.answerId),
+    onMutate: () => {
+      setAnswerLiked(!answerLiked);
+    },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        errorToast({
+          title: "좋아요 실패",
+          description: error.response?.data.message,
+        });
+      } else {
+        errorToast({
+          title: "좋아요 실패",
+          description: "서버 오류가 발생했습니다.",
+        });
+      }
+      setAnswerLiked(!answerLiked);
+    },
+  });
+
+  const badgeColor = useMemo(() => {
+    switch (questionAndFeedback.answerRank.toLowerCase()) {
+      case "A":
+        return "bg-purple-100 text-purple-800 border-purple-300";
+      case "B":
+        return "bg-blue-100 text-blue-800 border-blue-300";
+      case "C":
+        return "bg-yellow-100 text-yellow-800 border-yellow-300";
+      case "D":
+        return "bg-red-100 text-red-800 border-red-300";
+      default:
+        return "bg-gray-100 text-gray-800 border-gray-300";
+    }
+  }, [questionAndFeedback.answerRank]);
+
+  return (
+    <div
+      key={questionAndFeedback.answerId}
+      className="bg-white rounded-2xl shadow-lg overflow-hidden border border-gray-100 hover:shadow-xl transition-shadow duration-300"
+    >
+      {/* 질문 헤더 */}
+      <div className="bg-gradient-to-r from-blue-1 to-blue-2 p-6 border-b border-gray-100">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <div className="flex items-center space-x-3 mb-3">
+              <span className="bg-gradient-to-r from-blue-5 to-blue-6 text-white px-3 py-1 rounded-full text-sm font-medium">
+                Q{index + 1}
+              </span>
+              <span
+                className={`px-3 py-1 rounded-full text-sm font-medium border ${badgeColor}`}
+              >
+                {questionAndFeedback.answerRank}
+              </span>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              {questionAndFeedback.question}
+            </h3>
+          </div>
+          <Button
+            aria-busy={isPending}
+            disabled={isPending}
+            onClick={() => toggleInterviewLikeMutation(answerLiked)}
+            type="button"
+            name={`answer-like-button-${questionAndFeedback.answerId}`}
+            role="button"
+            variant="glass"
+            optimistic={true}
+            className={`${answerLiked && "bg-volcano-3 text-volcano-6 hover:bg-volcano-4"}`}
+            aria-label={`답변 ${index + 1} 좋아요`}
+          >
+            <Heart
+              className={`w-4 h-4 mr-2 ${answerLiked ? "fill-current" : ""}`}
+            />
+            <span className="text-sm font-medium">
+              {answerLiked
+                ? questionAndFeedback.answerLikeCount + 1
+                : questionAndFeedback.answerLikeCount}
+            </span>
+          </Button>
+        </div>
+      </div>
+
+      {/* 답변 및 피드백 내용 */}
+      <div className="p-6 space-y-6">
+        {/* 답변 섹션 */}
+        <div className="space-y-3">
+          <div className="flex items-center space-x-2">
+            <div className="w-3 h-3 bg-gradient-to-r from-blue-4 to-blue-5 rounded-full"></div>
+            <h4 className="text-sm font-semibold text-gray-700">응답 내용</h4>
+          </div>
+          <div className="bg-gradient-to-r from-blue-1 to-blue-2 rounded-xl p-4 border border-blue-3">
+            <p className="text-gray-800 leading-relaxed whitespace-pre-wrap">
+              {questionAndFeedback.answer}
+            </p>
+          </div>
+        </div>
+
+        {/* 피드백 섹션 */}
+        <div className="space-y-3">
+          <div className="flex items-center space-x-2">
+            <div className="w-3 h-3 bg-gradient-to-r from-cyan-4 to-cyan-5 rounded-full"></div>
+            <h4 className="text-sm font-semibold text-gray-700">AI 피드백</h4>
+          </div>
+          <div className="bg-gradient-to-r from-cyan-1 to-cyan-2 rounded-xl p-4 border border-cyan-3">
+            <p className="text-gray-800 leading-relaxed whitespace-pre-wrap">
+              {questionAndFeedback.answerFeedback}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/domains/members/components/memberQuestionFeedback.tsx
+++ b/apps/client/src/domains/members/components/memberQuestionFeedback.tsx
@@ -1,4 +1,3 @@
-import { TMemberInterviewResult } from "@/domains/members/types";
 import { useMutation } from "@tanstack/react-query";
 import { Heart } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -6,16 +5,20 @@ import { useToast } from "@kokomen/ui/hooks/useToast";
 import { isAxiosError } from "axios";
 import { Button } from "@kokomen/ui/components/button";
 import { toggleMemberInterviewAnswerLike } from "@/domains/members/api";
+import { CamelCasedProperties } from "@/utils/convertConvention";
+import { MemberInterviewResult } from "@/domains/members/types";
 
 export default function MemberQuestionFeedback({
   questionAndFeedback,
   index,
 }: {
-  questionAndFeedback: TMemberInterviewResult["feedbacks"][number];
+  questionAndFeedback: CamelCasedProperties<
+    MemberInterviewResult["feedbacks"][number]
+  >;
   index: number;
 }) {
   const [answerLiked, setAnswerLiked] = useState<boolean>(
-    questionAndFeedback.answerLiked
+    questionAndFeedback.answerAlreadyLiked
   );
   const { error: errorToast } = useToast();
   const { mutate: toggleInterviewLikeMutation, isPending } = useMutation({

--- a/apps/client/src/domains/members/components/memberTotalFeedback.tsx
+++ b/apps/client/src/domains/members/components/memberTotalFeedback.tsx
@@ -1,17 +1,18 @@
 import { toggleMemberInterviewLike } from "@/domains/members/api";
-import { TMemberInterviewResult } from "@/domains/members/types";
 import { useMutation } from "@tanstack/react-query";
 import { CheckCircle, Heart, MessageCircle, Trophy } from "lucide-react";
 import { JSX, useState } from "react";
 import { useToast } from "@kokomen/ui/hooks/useToast";
 import { isAxiosError } from "axios";
 import { Button } from "@kokomen/ui/components/button";
+import { MemberInterviewResult } from "@/domains/members/types";
+import { CamelCasedProperties } from "@/utils/convertConvention";
 
 export default function MemberTotalFeedback({
   result,
   interviewId,
 }: {
-  result: TMemberInterviewResult;
+  result: CamelCasedProperties<MemberInterviewResult>;
   interviewId: number;
 }): JSX.Element {
   const [isTotalLikedIncludesMine, setIsTotalLikedIncludesMine] =

--- a/apps/client/src/domains/members/components/memberTotalFeedback.tsx
+++ b/apps/client/src/domains/members/components/memberTotalFeedback.tsx
@@ -1,0 +1,119 @@
+import { toggleMemberInterviewLike } from "@/domains/members/api";
+import { TMemberInterviewResult } from "@/domains/members/types";
+import { useMutation } from "@tanstack/react-query";
+import { CheckCircle, Heart, MessageCircle, Trophy } from "lucide-react";
+import { JSX, useState } from "react";
+import { useToast } from "@kokomen/ui/hooks/useToast";
+import { isAxiosError } from "axios";
+import { Button } from "@kokomen/ui/components/button";
+
+export default function MemberTotalFeedback({
+  result,
+  interviewId,
+}: {
+  result: TMemberInterviewResult;
+  interviewId: number;
+}): JSX.Element {
+  const [isTotalLikedIncludesMine, setIsTotalLikedIncludesMine] =
+    useState<boolean>(result.interviewAlreadyLiked);
+  const { error: errorToast } = useToast();
+  const { mutate: toggleInterviewLikeMutation, isPending } = useMutation({
+    mutationFn: (liked: boolean) =>
+      toggleMemberInterviewLike(liked, interviewId),
+    onMutate: () => {
+      setIsTotalLikedIncludesMine(!isTotalLikedIncludesMine);
+    },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        errorToast({
+          title: "좋아요 실패",
+          description: error.response?.data.message,
+        });
+      } else {
+        errorToast({
+          title: "좋아요 실패",
+          description: "서버 오류가 발생했습니다.",
+        });
+        setIsTotalLikedIncludesMine(!isTotalLikedIncludesMine);
+      }
+    },
+  });
+
+  return (
+    <div className="p-8">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+        {/* 총점 */}
+        <div className="text-center">
+          <div className="w-16 h-16 bg-gradient-primary rounded-full flex items-center justify-center mx-auto mb-4">
+            <Trophy className="w-8 h-8 text-white" />
+          </div>
+          <p className="text-2xl font-bold text-gray-900">
+            {result.totalScore}
+          </p>
+          <p className="text-sm text-gray-600">총점</p>
+        </div>
+
+        {/* 질문 수 */}
+        <div className="text-center">
+          <div className="w-16 h-16 bg-gradient-to-br from-emerald-400 to-teal-500 rounded-full flex items-center justify-center mx-auto mb-4">
+            <MessageCircle className="w-8 h-8 text-white" />
+          </div>
+          <p className="text-2xl font-bold text-gray-900">
+            {result.feedbacks.length}
+          </p>
+          <p className="text-sm text-gray-600">질문 수</p>
+        </div>
+
+        {/* 전체 좋아요 수 */}
+        <div className="text-center">
+          <div className="w-16 h-16 bg-gradient-to-br from-pink-400 to-rose-500 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Heart className="w-8 h-8 text-white" />
+          </div>
+          <p className="text-2xl font-bold text-gray-900">
+            {result.interviewLikeCount}
+          </p>
+          <p className="text-sm text-gray-600">좋아요</p>
+        </div>
+      </div>
+
+      <div className="bg-gradient-to-r from-blue-1 to-blue-2 rounded-2xl p-6 border border-blue-3">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 bg-gradient-to-br from-blue-5 to-blue-6 rounded-full flex items-center justify-center">
+              <CheckCircle className="w-5 h-5 text-white" />
+            </div>
+            <h2 className="text-xl font-bold text-gray-900">종합 평가</h2>
+          </div>
+          <Button
+            optimistic
+            disabled={isPending}
+            aria-busy={isPending}
+            onClick={() =>
+              toggleInterviewLikeMutation(isTotalLikedIncludesMine)
+            }
+            name={`interview-like-button-${interviewId}`}
+            role="button"
+            type="button"
+            variant="glass"
+            className={`${isTotalLikedIncludesMine && "bg-volcano-3 text-volcano-6 hover:bg-volcano-4"}`}
+            aria-label="전체 인터뷰 좋아요"
+          >
+            <Heart
+              className={`w-5 h-5 mr-2 ${isTotalLikedIncludesMine ? "fill-current" : ""}`}
+            />
+            <span className="text-sm font-medium">
+              {isTotalLikedIncludesMine
+                ? result.interviewLikeCount + 1
+                : result.interviewLikeCount}
+            </span>
+          </Button>
+        </div>
+        <div className="bg-white rounded-xl p-6 shadow-sm border border-white/50">
+          <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
+            {result.totalFeedback}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/domains/members/components/rankCard.tsx
+++ b/apps/client/src/domains/members/components/rankCard.tsx
@@ -3,8 +3,9 @@ import { memberKeys } from "@/utils/querykeys";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 import { Button } from "@kokomen/ui/components/button";
+import { JSX } from "react";
 
-export default function RankCard() {
+export default function RankCard(): JSX.Element {
   const { data } = useQuery({
     queryKey: memberKeys.rank(),
     queryFn: () => getRankList(),

--- a/apps/client/src/domains/members/types/index.ts
+++ b/apps/client/src/domains/members/types/index.ts
@@ -5,4 +5,53 @@ type Rank = {
   finished_interview_count: number;
 };
 
-export type { Rank };
+type TMemberInterviewResponse = {
+  interview_id: number;
+  interview_state: "FINISHED";
+  interview_category: string;
+  created_at: string;
+  root_question: string;
+  max_question_count: number;
+  score: number;
+};
+
+type TMemberInterview = {
+  interviewId: number;
+  interviewState: "FINISHED";
+  interviewCategory: string;
+  createdAt: string;
+  rootQuestion: string;
+  maxQuestionCount: number;
+  score: number;
+};
+
+class MemberInterview implements TMemberInterview {
+  public interviewId: number;
+  public interviewState: "FINISHED";
+  public interviewCategory: string;
+  public createdAt: string;
+  public rootQuestion: string;
+  public maxQuestionCount: number;
+  public score: number;
+
+  public constructor(interview: TMemberInterviewResponse) {
+    this.interviewId = interview.interview_id;
+    this.interviewState = interview.interview_state;
+    this.interviewCategory = interview.interview_category;
+    this.createdAt = interview.created_at;
+    this.rootQuestion = interview.root_question;
+    this.maxQuestionCount = interview.max_question_count;
+    this.score = interview.score;
+  }
+
+  public get formattedCreatedDate(): string {
+    return new Date(this.createdAt).toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
+}
+
+export type { Rank, TMemberInterview, TMemberInterviewResponse };
+export { MemberInterview };

--- a/apps/client/src/domains/members/types/index.ts
+++ b/apps/client/src/domains/members/types/index.ts
@@ -12,6 +12,7 @@ type InterviewSummary = {
   root_question: string;
   max_question_count: number;
   score: 20;
+  interview_view_count: number;
   interview_like_count: number;
   interview_already_liked: boolean;
 };

--- a/apps/client/src/domains/members/types/index.ts
+++ b/apps/client/src/domains/members/types/index.ts
@@ -21,6 +21,7 @@ type MemberInterview = {
   total_member_count: number;
   interviewee_rank: number;
   interviewee_nickname: string;
+  total_page_count: number;
 };
 
 type Feedback = {

--- a/apps/client/src/domains/members/types/index.ts
+++ b/apps/client/src/domains/members/types/index.ts
@@ -1,3 +1,28 @@
+type Rank = {
+  id: number;
+  nickname: string;
+  score: number;
+  finished_interview_count: number;
+};
+
+type InterviewSummary = {
+  interview_id: number;
+  interview_category: string;
+  created_at: string;
+  root_question: string;
+  max_question_count: number;
+  score: 20;
+  interview_like_count: number;
+  interview_already_liked: boolean;
+};
+
+type MemberInterview = {
+  interview_summaries: InterviewSummary[];
+  total_member_count: number;
+  interviewee_rank: number;
+  interviewee_nickname: string;
+};
+
 type Feedback = {
   question_id: number;
   answer_id: number;
@@ -9,113 +34,15 @@ type Feedback = {
   answer_already_liked: boolean;
 };
 
-type Rank = {
-  id: number;
-  nickname: string;
-  score: number;
-  finished_interview_count: number;
-};
-
-type TMemberInterviewResponse = {
-  interview_id: number;
-  interview_state: "FINISHED";
-  interview_category: string;
-  created_at: string;
-  root_question: string;
-  max_question_count: number;
-  score: number;
-};
-
-type TMemberInterview = {
-  interviewId: number;
-  interviewState: "FINISHED";
-  interviewCategory: string;
-  createdAt: string;
-  rootQuestion: string;
-  maxQuestionCount: number;
-  score: number;
-};
-
-class MemberInterview implements TMemberInterview {
-  public interviewId: number;
-  public interviewState: "FINISHED";
-  public interviewCategory: string;
-  public createdAt: string;
-  public rootQuestion: string;
-  public maxQuestionCount: number;
-  public score: number;
-
-  public constructor(interview: TMemberInterviewResponse) {
-    this.interviewId = interview.interview_id;
-    this.interviewState = interview.interview_state;
-    this.interviewCategory = interview.interview_category;
-    this.createdAt = interview.created_at;
-    this.rootQuestion = interview.root_question;
-    this.maxQuestionCount = interview.max_question_count;
-    this.score = interview.score;
-  }
-
-  public get formattedCreatedDate(): string {
-    return new Date(this.createdAt).toLocaleDateString("ko-KR", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  }
-}
-
-type TMemberInterviewResultResponse = {
+type MemberInterviewResult = {
   feedbacks: Feedback[];
   total_feedback: string;
   total_score: number;
   interview_like_count: number;
   interview_already_liked: boolean;
+  interviewee_rank: number;
+  total_member_count: number;
+  interviewee_nickname: string;
 };
 
-type TMemberInterviewResult = {
-  feedbacks: {
-    questionId: number;
-    answerId: number;
-    question: string;
-    answer: string;
-    answerRank: string;
-    answerFeedback: string;
-    answerLikeCount: number;
-    answerLiked: boolean;
-  }[];
-  totalFeedback: string;
-  totalScore: number;
-  interviewLikeCount: number;
-  interviewAlreadyLiked: boolean;
-};
-
-const mapToMemberInterviewResult = (
-  response: TMemberInterviewResultResponse
-): TMemberInterviewResult => {
-  return {
-    feedbacks: response.feedbacks.map((feedback) => ({
-      questionId: feedback.question_id,
-      answerId: feedback.answer_id,
-      question: feedback.question,
-      answer: feedback.answer,
-      answerRank: feedback.answer_rank,
-      answerFeedback: feedback.answer_feedback,
-      answerLikeCount: feedback.answer_like_count,
-      answerLiked: feedback.answer_already_liked,
-    })),
-    totalFeedback: response.total_feedback,
-    totalScore: response.total_score,
-    interviewLikeCount: response.interview_like_count,
-    interviewAlreadyLiked: response.interview_already_liked,
-  };
-};
-
-export type {
-  Feedback,
-  Rank,
-  TMemberInterview,
-  TMemberInterviewResponse,
-  TMemberInterviewResult,
-  TMemberInterviewResultResponse,
-};
-export { MemberInterview, mapToMemberInterviewResult };
+export type { Feedback, Rank, MemberInterview, MemberInterviewResult };

--- a/apps/client/src/domains/members/types/index.ts
+++ b/apps/client/src/domains/members/types/index.ts
@@ -1,3 +1,14 @@
+type Feedback = {
+  question_id: number;
+  answer_id: number;
+  question: string;
+  answer: string;
+  answer_rank: string;
+  answer_feedback: string;
+  answer_like_count: number;
+  answer_already_liked: boolean;
+};
+
 type Rank = {
   id: number;
   nickname: string;
@@ -53,5 +64,58 @@ class MemberInterview implements TMemberInterview {
   }
 }
 
-export type { Rank, TMemberInterview, TMemberInterviewResponse };
-export { MemberInterview };
+type TMemberInterviewResultResponse = {
+  feedbacks: Feedback[];
+  total_feedback: string;
+  total_score: number;
+  interview_like_count: number;
+  interview_already_liked: boolean;
+};
+
+type TMemberInterviewResult = {
+  feedbacks: {
+    questionId: number;
+    answerId: number;
+    question: string;
+    answer: string;
+    answerRank: string;
+    answerFeedback: string;
+    answerLikeCount: number;
+    answerLiked: boolean;
+  }[];
+  totalFeedback: string;
+  totalScore: number;
+  interviewLikeCount: number;
+  interviewAlreadyLiked: boolean;
+};
+
+const mapToMemberInterviewResult = (
+  response: TMemberInterviewResultResponse
+): TMemberInterviewResult => {
+  return {
+    feedbacks: response.feedbacks.map((feedback) => ({
+      questionId: feedback.question_id,
+      answerId: feedback.answer_id,
+      question: feedback.question,
+      answer: feedback.answer,
+      answerRank: feedback.answer_rank,
+      answerFeedback: feedback.answer_feedback,
+      answerLikeCount: feedback.answer_like_count,
+      answerLiked: feedback.answer_already_liked,
+    })),
+    totalFeedback: response.total_feedback,
+    totalScore: response.total_score,
+    interviewLikeCount: response.interview_like_count,
+    interviewAlreadyLiked: response.interview_already_liked,
+  };
+};
+
+export type {
+  Feedback,
+  Rank,
+  TMemberInterview,
+  TMemberInterviewResponse,
+  TMemberInterviewResult,
+  TMemberInterviewResultResponse,
+};
+export { MemberInterview, mapToMemberInterviewResult };

--- a/apps/client/src/hooks/useScreenSize.ts
+++ b/apps/client/src/hooks/useScreenSize.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+export const useScreenSize = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkScreenSize = () => {
+      setIsMobile(window.innerWidth < 768); // md breakpoint
+    };
+
+    checkScreenSize();
+    window.addEventListener("resize", checkScreenSize);
+
+    return () => window.removeEventListener("resize", checkScreenSize);
+  }, []);
+
+  return { isMobile };
+};

--- a/apps/client/src/pages/_app.tsx
+++ b/apps/client/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import type { AppProps } from "next/app";
 import { JSX } from "react";
 import { Toaster } from "@kokomen/ui/components/toast/toaster";
 import { ErrorBoundary } from "@sentry/nextjs";
-import Error from "@/pages/_error";
+import ErrorFallback from "@/shared/errorFallback";
 
 const queryClient: QueryClient = new QueryClient();
 
@@ -12,9 +12,7 @@ const queryClient: QueryClient = new QueryClient();
 export default function App({ Component, pageProps }: AppProps): JSX.Element {
   return (
     <QueryClientProvider client={queryClient}>
-      <ErrorBoundary
-        fallback={<Error statusCode={500} hasGetInitialProps={false} />}
-      >
+      <ErrorBoundary fallback={<ErrorFallback />}>
         <Toaster>
           <Component {...pageProps} />
         </Toaster>

--- a/apps/client/src/pages/_error.tsx
+++ b/apps/client/src/pages/_error.tsx
@@ -5,7 +5,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { ErrorProps } from "next/error";
-import { JSX, useEffect, useState } from "react";
+import { JSX } from "react";
 
 interface CustomErrorProps extends ErrorProps {
   hasGetInitialProps: boolean;
@@ -13,7 +13,6 @@ interface CustomErrorProps extends ErrorProps {
 
 function Error({ statusCode }: CustomErrorProps): JSX.Element {
   const router = useRouter();
-  const [countdown, setCountdown] = useState(10);
 
   const getErrorInfo = (statusCode: number) => {
     switch (statusCode) {
@@ -23,7 +22,7 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
           description:
             "일시적인 서버 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
           emoji: "🔧",
-          bgClasses: "bg-gradient-to-br from-red-500 to-red-700",
+          bgClasses: "bg-slate-50",
           suggestion: "페이지를 새로고침하거나 잠시 후 다시 접속해보세요.",
         };
       case 502:
@@ -31,7 +30,7 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
           title: "게이트웨이 오류",
           description: "서버 간 통신에 문제가 발생했습니다.",
           emoji: "🌐",
-          bgClasses: "bg-gradient-to-br from-purple-500 to-purple-700",
+          bgClasses: "bg-blue-50",
           suggestion: "네트워크 연결을 확인하고 다시 시도해주세요.",
         };
       case 503:
@@ -40,7 +39,7 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
           description:
             "현재 서비스 점검 중이거나 일시적으로 이용할 수 없습니다.",
           emoji: "🚧",
-          bgClasses: "bg-gradient-to-br from-orange-500 to-orange-700",
+          bgClasses: "bg-amber-50",
           suggestion: "점검이 완료될 때까지 잠시만 기다려주세요.",
         };
       case 504:
@@ -48,7 +47,7 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
           title: "게이트웨이 타임아웃",
           description: "서버 응답 시간이 초과되었습니다.",
           emoji: "⏱️",
-          bgClasses: "bg-gradient-to-br from-yellow-500 to-yellow-700",
+          bgClasses: "bg-orange-50",
           suggestion: "잠시 후 다시 시도해주세요.",
         };
       default:
@@ -56,29 +55,13 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
           title: "서버 오류가 발생했습니다",
           description: "예상치 못한 서버 문제가 발생했습니다.",
           emoji: "⚠️",
-          bgClasses: "bg-gradient-to-br from-gray-500 to-gray-700",
+          bgClasses: "bg-gray-50",
           suggestion: "문제가 지속되면 고객센터로 문의해주세요.",
         };
     }
   };
 
   const errorInfo = getErrorInfo(statusCode || 500);
-
-  // 자동 홈 리다이렉션 카운트다운
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) {
-          clearInterval(timer);
-          router.push("/");
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, [router]);
 
   const handleRefresh = () => {
     window.location.reload();
@@ -102,52 +85,41 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
       </Head>
 
       <div
-        className={`min-h-screen flex items-center justify-center text-white font-sans relative overflow-hidden ${errorInfo.bgClasses}`}
+        className={`min-h-screen flex items-center justify-center ${errorInfo.bgClasses}`}
       >
-        <div className="text-center max-w-2xl px-8 z-10 relative">
-          {/* 에러 아이콘과 애니메이션 */}
+        <div className="text-center max-w-2xl px-8">
+          {/* 에러 아이콘 */}
           <div className="mb-8">
-            <div className="text-8xl animate-bounce inline-block">
-              {errorInfo.emoji}
-            </div>
+            <div className="text-6xl">{errorInfo.emoji}</div>
           </div>
 
           {/* 에러 코드 */}
           <div className="mb-6">
-            <span className="text-9xl font-black leading-none bg-gradient-to-r from-white to-white/80 bg-clip-text text-transparent drop-shadow-lg">
+            <span className="text-8xl font-bold text-gray-800">
               {statusCode}
             </span>
           </div>
 
           {/* 에러 제목 */}
-          <h1 className="text-4xl md:text-5xl font-bold mb-4 drop-shadow-md">
+          <h1 className="text-3xl md:text-4xl font-bold mb-4 text-gray-900">
             {errorInfo.title}
           </h1>
 
           {/* 에러 설명 */}
-          <p className="text-xl md:text-2xl mb-6 opacity-95 leading-relaxed">
+          <p className="text-lg md:text-xl mb-6 text-gray-600 leading-relaxed">
             {errorInfo.description}
           </p>
 
           {/* 제안 사항 */}
-          <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6 mb-6 border border-white/20">
-            <p className="text-lg font-medium">{errorInfo.suggestion}</p>
+          <div className="bg-white border border-gray-200 rounded-lg p-6 mb-8 shadow-sm">
+            <p className="text-gray-700 font-medium">{errorInfo.suggestion}</p>
           </div>
-
-          {/* 자동 리다이렉션 카운트다운 */}
-          {countdown > 0 && (
-            <div className="bg-black/20 backdrop-blur-sm rounded-lg p-4 mb-8 border border-white/10">
-              <p className="text-lg font-semibold">
-                {countdown}초 후 홈페이지로 이동합니다...
-              </p>
-            </div>
-          )}
 
           {/* 액션 버튼들 */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-8">
             <Link
               href="/"
-              className="flex items-center gap-2 px-6 py-3 bg-white text-gray-800 rounded-xl font-semibold text-lg transition-all duration-300 hover:bg-gray-100 hover:-translate-y-1 hover:shadow-xl min-w-[200px] justify-center"
+              className="flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg font-medium text-lg transition-colors duration-200 hover:bg-blue-700 min-w-[200px] justify-center"
             >
               <span>🏠</span>
               홈으로 돌아가기
@@ -155,7 +127,7 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
 
             <button
               onClick={handleGoBack}
-              className="flex items-center gap-2 px-6 py-3 bg-white/20 backdrop-blur-sm text-white rounded-xl font-semibold text-lg border border-white/30 transition-all duration-300 hover:bg-white/30 hover:-translate-y-1 hover:shadow-xl min-w-[200px] justify-center"
+              className="flex items-center gap-2 px-6 py-3 bg-gray-600 text-white rounded-lg font-medium text-lg transition-colors duration-200 hover:bg-gray-700 min-w-[200px] justify-center"
             >
               <span>⬅️</span>
               이전 페이지로
@@ -163,7 +135,7 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
 
             <button
               onClick={handleRefresh}
-              className="flex items-center gap-2 px-6 py-3 bg-white/20 backdrop-blur-sm text-white rounded-xl font-semibold text-lg border border-white/30 transition-all duration-300 hover:bg-white/30 hover:-translate-y-1 hover:shadow-xl min-w-[200px] justify-center"
+              className="flex items-center gap-2 px-6 py-3 bg-green-600 text-white rounded-lg font-medium text-lg transition-colors duration-200 hover:bg-green-700 min-w-[200px] justify-center"
             >
               <span>🔄</span>
               새로고침
@@ -171,45 +143,32 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
           </div>
 
           {/* 추가 도움말 */}
-          <details className="bg-white/10 backdrop-blur-sm rounded-lg p-4 border border-white/20 text-left">
-            <summary className="cursor-pointer font-semibold text-center mb-2 hover:text-white/80">
+          <details className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm text-left">
+            <summary className="cursor-pointer font-medium text-center mb-2 text-gray-800 hover:text-gray-600">
               문제 해결 도움말
             </summary>
             <div className="mt-3">
-              <ul className="space-y-2 text-sm md:text-base">
+              <ul className="space-y-2 text-sm md:text-base text-gray-600">
                 <li className="flex items-start gap-2">
-                  <span className="text-white/70">•</span>
+                  <span className="text-gray-400">•</span>
                   브라우저 캐시를 지우고 다시 시도해보세요
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-white/70">•</span>
+                  <span className="text-gray-400">•</span>
                   다른 브라우저에서 접속해보세요
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-white/70">•</span>
+                  <span className="text-gray-400">•</span>
                   인터넷 연결 상태를 확인해보세요
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-white/70">•</span>
+                  <span className="text-gray-400">•</span>
                   VPN을 사용 중이라면 해제 후 시도해보세요
                 </li>
               </ul>
             </div>
           </details>
         </div>
-
-        {/* 배경 애니메이션 */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none">
-          <div className="absolute top-1/4 left-1/4 w-24 h-24 bg-white/10 rounded-full animate-pulse"></div>
-          <div className="absolute top-3/4 right-1/4 w-32 h-32 bg-white/5 rounded-full animate-ping"></div>
-          <div className="absolute bottom-1/4 left-1/5 w-20 h-20 bg-white/10 rounded-full animate-bounce"></div>
-        </div>
-
-        {/* 추가 플로팅 애니메이션 */}
-        <div className="absolute top-10 left-10 w-4 h-4 bg-white/20 rounded-full animate-ping"></div>
-        <div className="absolute top-20 right-20 w-6 h-6 bg-white/15 rounded-full animate-pulse"></div>
-        <div className="absolute bottom-20 right-10 w-5 h-5 bg-white/20 rounded-full animate-bounce"></div>
-        <div className="absolute bottom-10 left-20 w-3 h-3 bg-white/25 rounded-full animate-ping"></div>
       </div>
     </>
   );
@@ -218,7 +177,11 @@ function Error({ statusCode }: CustomErrorProps): JSX.Element {
 Error.getInitialProps = async (contextData: NextPageContext) => {
   // In case this is running in a serverless function, await this in order to give Sentry
   // time to send the error before the lambda exits
-  await Sentry.captureUnderscoreErrorException(contextData);
+  try {
+    await Sentry.captureUnderscoreErrorException(contextData);
+  } catch {
+    console.error("CLIENT ERROR : SENTRY ERROR");
+  }
 
   // This will contain the status code of the response
   const { res, err } = contextData;

--- a/apps/client/src/pages/dashboard/index.tsx
+++ b/apps/client/src/pages/dashboard/index.tsx
@@ -7,14 +7,27 @@ import {
   InferGetServerSidePropsType,
 } from "next";
 import Head from "next/head";
-import { Coins, User, Star } from "lucide-react";
+import { Coins, User, Star, TrendingUp } from "lucide-react";
 import InterviewHistory from "@/domains/dashboard/components/interviewHistory";
 import { User as UserType } from "@/domains/auth/types";
 import { JSX } from "react";
+import { getRankDisplay, getPercentileDisplay } from "@/utils/rankDisplay";
 
 export default function Dashboard({
   userInfo,
 }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+  const percentile = userInfo
+    ? 100 -
+      Math.round(
+        ((userInfo.total_member_count - userInfo.rank + 1) /
+          userInfo.total_member_count) *
+          100
+      )
+    : 0;
+
+  const rankDisplay = userInfo ? getRankDisplay(userInfo.rank) : null;
+  const RankIcon = rankDisplay?.icon;
+
   return (
     <>
       <Head>
@@ -30,7 +43,7 @@ export default function Dashboard({
       <main className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50">
         <Header user={userInfo} />
         <div className="mb-2 p-4 max-w-[1280px] mx-auto">
-          <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 mb-6">
+          <div className="rounded-2xl shadow-sm border border-gray-200 p-6 mb-6 bg-gradient-primary">
             <div className="flex items-center justify-between md:flex-row flex-col gap-4">
               <div className="flex items-center space-x-4">
                 <div className="w-16 h-16 bg-gradient-to-br from-primary-hover to-primary rounded-full flex items-center justify-center">
@@ -43,11 +56,38 @@ export default function Dashboard({
                 </div>
               </div>
               <div className="text-right flex items-center gap-5">
+                {/* 랭킹 표시 */}
+                {userInfo && rankDisplay && RankIcon && (
+                  <div
+                    className={`flex items-center gap-2 text-lg font-semibold ${rankDisplay.bgColor} text-gray-700 rounded-xl px-4 py-2`}
+                  >
+                    <RankIcon className={`w-5 h-5 ${rankDisplay.color}`} />
+                    <div>
+                      <div className="text-sm font-medium">랭킹</div>
+                      <div className="text-lg font-bold">{userInfo.rank}위</div>
+                    </div>
+                  </div>
+                )}
+
+                {/* 상위 백분위 표시 */}
+                {userInfo && (
+                  <div
+                    className={`flex items-center gap-2 text-lg font-semibold ${getPercentileDisplay(percentile).bgColor} ${getPercentileDisplay(percentile).color} rounded-xl px-4 py-2`}
+                  >
+                    <TrendingUp className="w-5 h-5" />
+                    <div>
+                      <div className="text-sm font-medium">상위</div>
+                      <div className="text-lg font-bold">{percentile}%</div>
+                    </div>
+                  </div>
+                )}
+
                 {/* 점수 표시 */}
                 <div className="flex items-center gap-2 text-lg font-semibold bg-gradient-to-br from-primary-hover to-primary text-text-light-solid rounded-xl px-4 py-2">
                   <Star className="w-5 h-5" />
                   <span>{userInfo?.score || 0}점</span>
                 </div>
+
                 {/* 토큰 표시 */}
                 <div className="flex items-center gap-2 text-lg font-semibold bg-gradient-to-br from-gold-4 to-gold-6 text-text-light-solid rounded-xl px-4 py-2">
                   <Coins className="w-5 h-5" />
@@ -55,6 +95,34 @@ export default function Dashboard({
                 </div>
               </div>
             </div>
+
+            {/* 랭킹 진행 바 */}
+            {userInfo && (
+              <div className="mt-6 pt-4 border-t border-gray-200">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm text-gray-600">
+                    전체 멤버 중 위치
+                  </span>
+                  <span
+                    className={`text-sm font-medium ${
+                      getPercentileDisplay(percentile).color
+                    }`}
+                  >
+                    상위 {percentile}%
+                  </span>
+                </div>
+                <div className="w-full bg-gray-200 rounded-full h-2">
+                  <div
+                    className="bg-gradient-to-r from-green-500 to-blue-500 h-2 rounded-full transition-all duration-500"
+                    style={{ width: `${100 - percentile}%` }}
+                  />
+                </div>
+                <div className="flex justify-between mt-1 text-xs text-gray-500">
+                  <span>{userInfo.total_member_count}위</span>
+                  <span>1위</span>
+                </div>
+              </div>
+            )}
           </div>
         </div>
         <InterviewHistory />

--- a/apps/client/src/pages/dashboard/index.tsx
+++ b/apps/client/src/pages/dashboard/index.tsx
@@ -55,43 +55,48 @@ export default function Dashboard({
                   </h1>
                 </div>
               </div>
-              <div className="text-right flex items-center gap-5">
+              <div className="text-right flex items-center gap-5 flex-col md:flex-row">
                 {/* 랭킹 표시 */}
-                {userInfo && rankDisplay && RankIcon && (
-                  <div
-                    className={`flex items-center gap-2 text-lg font-semibold ${rankDisplay.bgColor} text-gray-700 rounded-xl px-4 py-2`}
-                  >
-                    <RankIcon className={`w-5 h-5 ${rankDisplay.color}`} />
-                    <div>
-                      <div className="text-sm font-medium">랭킹</div>
-                      <div className="text-lg font-bold">{userInfo.rank}위</div>
+                <div className="flex items-center gap-2">
+                  {userInfo && rankDisplay && RankIcon && (
+                    <div
+                      className={`flex items-center gap-2 text-lg font-semibold ${rankDisplay.bgColor} text-gray-700 rounded-xl px-4 py-2`}
+                    >
+                      <RankIcon className={`w-5 h-5 ${rankDisplay.color}`} />
+                      <div>
+                        <div className="text-sm font-medium">랭킹</div>
+                        <div className="text-lg font-bold">
+                          {userInfo.rank}위
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
 
-                {/* 상위 백분위 표시 */}
-                {userInfo && (
-                  <div
-                    className={`flex items-center gap-2 text-lg font-semibold ${getPercentileDisplay(percentile).bgColor} ${getPercentileDisplay(percentile).color} rounded-xl px-4 py-2`}
-                  >
-                    <TrendingUp className="w-5 h-5" />
-                    <div>
-                      <div className="text-sm font-medium">상위</div>
-                      <div className="text-lg font-bold">{percentile}%</div>
+                  {/* 상위 백분위 표시 */}
+                  {userInfo && (
+                    <div
+                      className={`flex items-center gap-2 text-lg font-semibold ${getPercentileDisplay(percentile).bgColor} ${getPercentileDisplay(percentile).color} rounded-xl px-4 py-2`}
+                    >
+                      <TrendingUp className="w-5 h-5" />
+                      <div>
+                        <div className="text-sm font-medium">상위</div>
+                        <div className="text-lg font-bold">{percentile}%</div>
+                      </div>
                     </div>
-                  </div>
-                )}
-
-                {/* 점수 표시 */}
-                <div className="flex items-center gap-2 text-lg font-semibold bg-gradient-to-br from-primary-hover to-primary text-text-light-solid rounded-xl px-4 py-2">
-                  <Star className="w-5 h-5" />
-                  <span>{userInfo?.score || 0}점</span>
+                  )}
                 </div>
+                <div className="flex items-center gap-2 ">
+                  {/* 점수 표시 */}
+                  <div className="flex items-center gap-2 text-lg font-semibold bg-gradient-to-br from-primary-hover to-primary text-text-light-solid rounded-xl px-4 py-2">
+                    <Star className="w-5 h-5" />
+                    <span>{userInfo?.score || 0}점</span>
+                  </div>
 
-                {/* 토큰 표시 */}
-                <div className="flex items-center gap-2 text-lg font-semibold bg-gradient-to-br from-gold-4 to-gold-6 text-text-light-solid rounded-xl px-4 py-2">
-                  <Coins className="w-5 h-5" />
-                  <span>{userInfo?.token_count || 0} 토큰</span>
+                  {/* 토큰 표시 */}
+                  <div className="flex items-center gap-2 text-lg font-semibold bg-gradient-to-br from-gold-4 to-gold-6 text-text-light-solid rounded-xl px-4 py-2">
+                    <Coins className="w-5 h-5" />
+                    <span>{userInfo?.token_count || 0} 토큰</span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/client/src/pages/dashboard/index.tsx
+++ b/apps/client/src/pages/dashboard/index.tsx
@@ -134,12 +134,15 @@ export default function Dashboard({
 export const getServerSideProps = async (
   context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<{ userInfo: UserType }>> => {
-  return withCheckInServer(async () => {
-    const userInfo = await getUserInfo(context);
-    return {
-      data: {
-        userInfo: userInfo.data,
-      },
-    };
-  });
+  return withCheckInServer(
+    async () => {
+      const userInfo = await getUserInfo(context);
+      return {
+        data: {
+          userInfo: userInfo.data,
+        },
+      };
+    },
+    { authCheck: true, context }
+  );
 };

--- a/apps/client/src/pages/interviews/[interviewId]/result.tsx
+++ b/apps/client/src/pages/interviews/[interviewId]/result.tsx
@@ -187,8 +187,10 @@ export const getServerSideProps: GetServerSideProps<
       getUserInfo(context),
     ]);
     return {
-      report: report.data,
-      userInfo: userInfo.data,
+      data: {
+        report: report.data,
+        userInfo: userInfo.data,
+      },
     };
   });
 };

--- a/apps/client/src/pages/interviews/index.tsx
+++ b/apps/client/src/pages/interviews/index.tsx
@@ -139,7 +139,7 @@ export const getServerSideProps = async (
 
       return {
         data: { categories: categoryData, userInfo: userInfoData },
-      } as any;
+      };
     },
     {
       onError: () => {

--- a/apps/client/src/pages/interviews/index.tsx
+++ b/apps/client/src/pages/interviews/index.tsx
@@ -150,6 +150,8 @@ export const getServerSideProps = async (
           },
         };
       },
+      context,
+      authCheck: true,
     }
   );
 };

--- a/apps/client/src/pages/members/[memberId].tsx
+++ b/apps/client/src/pages/members/[memberId].tsx
@@ -1,0 +1,63 @@
+import { getUserInfo } from "@/domains/auth/api";
+import { User } from "@/domains/auth/types";
+import MemberInterviewHistory from "@/domains/members/components/memberInterviewHistory";
+import { isAxiosError } from "axios";
+import {
+  GetServerSideProps,
+  GetServerSidePropsResult,
+  InferGetServerSidePropsType,
+} from "next";
+import { Layout } from "@kokomen/ui/components/layout";
+import Header from "@/shared/header";
+import { JSX } from "react";
+
+export default function MemberInterviewPage({
+  memberId,
+  user,
+}: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+  return (
+    <Layout>
+      <Header user={user} />
+      <div className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-xl font-bold text-text-label mb-4">면접 기록</h1>
+        <MemberInterviewHistory memberId={Number(memberId)} />
+      </div>
+    </Layout>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<{
+  memberId: string;
+  user: User | null;
+}> = async (
+  context
+): Promise<
+  GetServerSidePropsResult<{ memberId: string; user: User | null }>
+> => {
+  const { memberId } = context.params as { memberId: string };
+  if (!memberId) {
+    return {
+      notFound: true,
+    };
+  }
+  try {
+    const { data: user } = await getUserInfo(context);
+    if (user.id) {
+      return {
+        props: { memberId, user },
+      };
+    }
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 401) {
+      return {
+        props: { memberId, user: null },
+      };
+    }
+  }
+  return {
+    redirect: {
+      destination: "/error",
+      permanent: false,
+    },
+  };
+};

--- a/apps/client/src/pages/members/[memberId].tsx
+++ b/apps/client/src/pages/members/[memberId].tsx
@@ -12,6 +12,46 @@ import { JSX } from "react";
 import { getMemberInterviews } from "@/domains/members/api";
 import { MemberInterview } from "@/domains/members/types";
 import { CamelCasedProperties } from "@/utils/convertConvention";
+import { Trophy, TrendingUp, Crown, Medal, Award } from "lucide-react";
+
+// 랭킹에 따른 아이콘과 색상 결정하는 함수
+const getRankDisplay = (rank: number) => {
+  if (rank === 1) {
+    return { icon: Crown, color: "text-gold-6", bgColor: "bg-gold-1" };
+  } else if (rank <= 3) {
+    return { icon: Medal, color: "text-gold-6", bgColor: "bg-gold-1" };
+  } else if (rank <= 10) {
+    return { icon: Award, color: "text-blue-6", bgColor: "bg-blue-1" };
+  } else {
+    return {
+      icon: Trophy,
+      color: "text-text-tertiary",
+      bgColor: "bg-fill-tertiary",
+    };
+  }
+};
+
+const getPercentileDisplay = (percentile: number) => {
+  if (percentile >= 90) {
+    return { color: "text-volcano-7" };
+  } else if (percentile >= 70) {
+    return { color: "text-volcano-6" };
+  } else if (percentile >= 60) {
+    return { color: "text-volcano-5" };
+  } else if (percentile >= 50) {
+    return { color: "text-volcano-4" };
+  } else if (percentile >= 40) {
+    return { color: "text-green-7" };
+  } else if (percentile >= 30) {
+    return { color: "text-green-6" };
+  } else if (percentile >= 20) {
+    return { color: "text-green-4" };
+  } else if (percentile >= 10) {
+    return { color: "text-primary" };
+  } else {
+    return { color: "text-gold-5" };
+  }
+};
 
 export default function MemberInterviewPage({
   memberId,
@@ -20,17 +60,112 @@ export default function MemberInterviewPage({
   sort,
   page,
 }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+  const percentile =
+    100 -
+    Math.round(
+      ((interviews.totalMemberCount - interviews.intervieweeRank + 1) /
+        interviews.totalMemberCount) *
+        100
+    );
+
+  const rankDisplay = getRankDisplay(interviews.intervieweeRank);
+  const RankIcon = rankDisplay.icon;
+
   return (
     <Layout>
       <Header user={user} />
-      <div className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-xl font-bold text-text-label mb-4">면접 기록</h1>
-        <MemberInterviewHistory
-          memberId={Number(memberId)}
-          interviewSummaries={interviews.interviewSummaries}
-          sort={sort}
-          page={page}
-        />
+      <div className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-8 py-8 ">
+        {/* 멤버 정보 카드 */}
+        <div className="bg-bg-elevated rounded-lg border border-border-secondary shadow-sm p-6 mb-6">
+          <div className="flex items-center justify-between flex-wrap gap-4">
+            <div className="flex items-center gap-4">
+              <div
+                className={`w-12 h-12 ${rankDisplay.bgColor} rounded-full flex items-center justify-center`}
+              >
+                <RankIcon className={`w-6 h-6 ${rankDisplay.color}`} />
+              </div>
+              <div>
+                <h1 className="text-xl font-bold text-text-heading">
+                  {interviews.intervieweeNickname}
+                </h1>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-6">
+              <div className="text-center">
+                <div className="flex items-center gap-2 mb-1">
+                  <RankIcon className={`w-4 h-4 ${rankDisplay.color}`} />
+                  <span className="text-sm font-medium text-text-label">
+                    랭킹
+                  </span>
+                </div>
+                <div className={`text-lg font-bold ${rankDisplay.color}`}>
+                  {interviews.intervieweeRank}위
+                </div>
+                <div className="text-xs text-text-tertiary">
+                  / {interviews.totalMemberCount}명
+                </div>
+              </div>
+
+              <div className="text-center">
+                <div className="flex items-center gap-2 mb-1">
+                  <TrendingUp
+                    className={`w-4 h-4 ${getPercentileDisplay(percentile).color}`}
+                  />
+                  <span className="text-sm font-medium text-text-label">
+                    상위
+                  </span>
+                </div>
+                <div
+                  className={`text-lg font-bold ${
+                    getPercentileDisplay(percentile).color
+                  }`}
+                >
+                  {percentile}%
+                </div>
+                <div className="text-xs text-text-tertiary">백분위</div>
+              </div>
+            </div>
+          </div>
+
+          {/* 진행 바로 상위 퍼센트 시각화 */}
+          <div className="mt-4 pt-4 border-t border-border-secondary">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm text-text-label">전체 멤버 중 위치</span>
+              <span
+                className={`text-sm font-medium ${
+                  getPercentileDisplay(percentile).color
+                }`}
+              >
+                상위 {percentile}%
+              </span>
+            </div>
+            <div className="w-full bg-fill-tertiary rounded-full h-2">
+              <div
+                className="bg-gradient-to-r from-green-6 to-blue-6 h-2 rounded-full transition-all duration-300"
+                style={{ width: `${100 - percentile}%` }}
+              />
+            </div>
+            <div className="flex justify-between mt-1 text-xs text-text-tertiary">
+              <span>{interviews.totalMemberCount}위</span>
+              <span>1위</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 면접 기록 섹션 */}
+        <div className="bg-bg-base rounded-lg border border-border-secondary shadow-sm p-6">
+          <h2 className="text-xl font-bold text-text-heading mb-4">
+            면접 기록
+          </h2>
+          <MemberInterviewHistory
+            memberId={Number(memberId)}
+            interviewSummaries={interviews.interviewSummaries}
+            sort={sort}
+            page={page}
+            totalPageCount={interviews.totalPageCount}
+          />
+        </div>
       </div>
     </Layout>
   );

--- a/apps/client/src/pages/members/[memberId].tsx
+++ b/apps/client/src/pages/members/[memberId].tsx
@@ -12,46 +12,8 @@ import { JSX } from "react";
 import { getMemberInterviews } from "@/domains/members/api";
 import { MemberInterview } from "@/domains/members/types";
 import { CamelCasedProperties } from "@/utils/convertConvention";
-import { Trophy, TrendingUp, Crown, Medal, Award } from "lucide-react";
-
-// 랭킹에 따른 아이콘과 색상 결정하는 함수
-const getRankDisplay = (rank: number) => {
-  if (rank === 1) {
-    return { icon: Crown, color: "text-gold-6", bgColor: "bg-gold-1" };
-  } else if (rank <= 3) {
-    return { icon: Medal, color: "text-gold-6", bgColor: "bg-gold-1" };
-  } else if (rank <= 10) {
-    return { icon: Award, color: "text-blue-6", bgColor: "bg-blue-1" };
-  } else {
-    return {
-      icon: Trophy,
-      color: "text-text-tertiary",
-      bgColor: "bg-fill-tertiary",
-    };
-  }
-};
-
-const getPercentileDisplay = (percentile: number) => {
-  if (percentile >= 90) {
-    return { color: "text-volcano-7" };
-  } else if (percentile >= 70) {
-    return { color: "text-volcano-6" };
-  } else if (percentile >= 60) {
-    return { color: "text-volcano-5" };
-  } else if (percentile >= 50) {
-    return { color: "text-volcano-4" };
-  } else if (percentile >= 40) {
-    return { color: "text-green-7" };
-  } else if (percentile >= 30) {
-    return { color: "text-green-6" };
-  } else if (percentile >= 20) {
-    return { color: "text-green-4" };
-  } else if (percentile >= 10) {
-    return { color: "text-primary" };
-  } else {
-    return { color: "text-gold-5" };
-  }
-};
+import { TrendingUp } from "lucide-react";
+import { getRankDisplay, getPercentileDisplay } from "@/utils/rankDisplay";
 
 export default function MemberInterviewPage({
   memberId,

--- a/apps/client/src/pages/members/[memberId].tsx
+++ b/apps/client/src/pages/members/[memberId].tsx
@@ -39,7 +39,7 @@ export default function MemberInterviewPage({
       <div className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-8 py-8 ">
         {/* 멤버 정보 카드 */}
         <div className="bg-bg-elevated rounded-lg border border-border-secondary shadow-sm p-6 mb-6">
-          <div className="flex items-center justify-between flex-wrap gap-4">
+          <div className="flex items-center justify-between flex-wrap gap-4 flex-col md:flex-row">
             <div className="flex items-center gap-4">
               <div
                 className={`w-12 h-12 ${rankDisplay.bgColor} rounded-full flex items-center justify-center`}

--- a/apps/client/src/pages/members/[memberId]/interviews/[interviewId].tsx
+++ b/apps/client/src/pages/members/[memberId]/interviews/[interviewId].tsx
@@ -1,0 +1,180 @@
+import { getUserInfo } from "@/domains/auth/api";
+import { User } from "@/domains/auth/types";
+import { getMemberInterviewResult } from "@/domains/members/api";
+import { TMemberInterviewResult } from "@/domains/members/types";
+import Header from "@/shared/header";
+import {
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+  InferGetServerSidePropsType,
+} from "next";
+import { Layout } from "@kokomen/ui/components/layout";
+import { JSX } from "react";
+import { HelpCircle, Info, Users, Share2, Eye } from "lucide-react";
+import MemberTotalFeedback from "@/domains/members/components/memberTotalFeedback";
+import MemberQuestionFeedback from "@/domains/members/components/memberQuestionFeedback";
+import { Button } from "@kokomen/ui/components/button";
+
+export default function MemberInterviewResultPage({
+  result,
+  user,
+  interviewId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+  const handleShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "면접 결과 공유",
+          text: `${result.totalScore}점의 면접 결과를 확인해보세요!`,
+          url: window.location.href,
+        });
+      } catch (err) {
+        console.log("공유 실패:", err);
+      }
+    } else {
+      await navigator.clipboard.writeText(window.location.href);
+    }
+  };
+
+  return (
+    <Layout>
+      <Header user={user} />
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          {/* 커뮤니티 스타일 헤더 */}
+          <div className="bg-white rounded-3xl shadow-xl overflow-hidden mb-8">
+            <div className="bg-gradient-to-r from-blue-6 to-blue-7 px-8 py-6">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center">
+                    <Users className="w-6 h-6 text-white" />
+                  </div>
+                  <div>
+                    <h1 className="text-2xl font-bold text-white">
+                      면접 결과 리포트
+                    </h1>
+                    <p className="text-blue-1 text-sm">
+                      {/* 멤버 이름 들어갈 곳 */}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <Button
+                    variant="glass"
+                    round
+                    onClick={handleShare}
+                    aria-label="공유하기"
+                  >
+                    <Share2 className="w-4 h-4 text-white mr-2" />
+                    <span className="text-sm font-medium text-white">
+                      공유하기
+                    </span>
+                  </Button>
+                </div>
+              </div>
+            </div>
+
+            {/* 점수 및 통계 섹션 */}
+
+            {/* 전체 피드백 카드 */}
+            <MemberTotalFeedback result={result} interviewId={interviewId} />
+          </div>
+
+          {/* 질문별 피드백 섹션 */}
+          <div className="space-y-6">
+            <div className="flex items-center justify-between mb-6">
+              <div className="flex items-center space-x-3">
+                <div className="w-10 h-10 bg-gradient-to-br from-blue-5 to-blue-6 rounded-full flex items-center justify-center">
+                  <HelpCircle className="w-5 h-5 text-white" />
+                </div>
+                <h2 className="text-2xl font-bold text-gray-900">
+                  질문별 상세 분석
+                </h2>
+              </div>
+              <div className="flex items-center text-sm text-gray-500">
+                <Eye className="w-4 h-4 mr-1" />
+                <span>커뮤니티 공개</span>
+              </div>
+            </div>
+
+            {result.feedbacks.map((feedback, index) => (
+              <MemberQuestionFeedback
+                key={feedback.answerId}
+                questionAndFeedback={feedback}
+                index={index}
+              />
+            ))}
+          </div>
+
+          {/* 커뮤니티 안내 메시지 */}
+          <div className="mt-12">
+            <div className="bg-gradient-to-r from-geek-blue-1 to-geek-blue-2 rounded-2xl p-6 border border-geek-blue-3">
+              <div className="flex items-center space-x-3 mb-3">
+                <div className="w-8 h-8 bg-gradient-to-br from-geek-blue-5 to-geek-blue-6 rounded-full flex items-center justify-center">
+                  <Info className="w-4 h-4 text-white" />
+                </div>
+                <h3 className="text-lg font-semibold text-geek-blue-8">
+                  커뮤니티 공유 안내
+                </h3>
+              </div>
+              <div className="space-y-2 text-sm text-geek-blue-7">
+                <p>
+                  • 이 결과는 AI가 분석한 내용이며, 학습 목적으로 커뮤니티에
+                  공유됩니다.
+                </p>
+                <p>• 좋아요를 눌러 유용한 답변에 반응을 남겨보세요.</p>
+                <p>
+                  • 개인정보는 포함되지 않으며, 면접 연습 개선을 위한 참고
+                  자료로 활용됩니다.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext<{
+    interviewId: string;
+    memberId: string;
+  }>
+): Promise<
+  GetServerSidePropsResult<{
+    result: TMemberInterviewResult;
+    user: User | null;
+    interviewId: number;
+  }>
+> => {
+  const { interviewId, memberId } = context.params as {
+    interviewId: string;
+    memberId: string;
+  };
+
+  if (!interviewId || !memberId || isNaN(Number(interviewId))) {
+    return { notFound: true };
+  }
+
+  const interviewIdNumber = Number(interviewId);
+  const [userResult, interviewResult] = await Promise.allSettled([
+    getUserInfo(context),
+    getMemberInterviewResult(interviewIdNumber, context),
+  ]);
+
+  if (interviewResult.status === "rejected") {
+    return { redirect: { destination: "/error", permanent: false } };
+  }
+
+  const result = interviewResult.value;
+  const user = userResult.status === "fulfilled" ? userResult.value.data : null;
+
+  return {
+    props: {
+      result,
+      user,
+      interviewId: interviewIdNumber,
+    },
+  };
+};

--- a/apps/client/src/pages/members/[memberId]/interviews/[interviewId].tsx
+++ b/apps/client/src/pages/members/[memberId]/interviews/[interviewId].tsx
@@ -1,7 +1,7 @@
 import { getUserInfo } from "@/domains/auth/api";
 import { User } from "@/domains/auth/types";
 import { getMemberInterviewResult } from "@/domains/members/api";
-import { TMemberInterviewResult } from "@/domains/members/types";
+import { MemberInterviewResult } from "@/domains/members/types";
 import Header from "@/shared/header";
 import {
   GetServerSidePropsContext,
@@ -14,6 +14,7 @@ import { HelpCircle, Info, Users, Share2, Eye } from "lucide-react";
 import MemberTotalFeedback from "@/domains/members/components/memberTotalFeedback";
 import MemberQuestionFeedback from "@/domains/members/components/memberQuestionFeedback";
 import { Button } from "@kokomen/ui/components/button";
+import { CamelCasedProperties } from "@/utils/convertConvention";
 
 export default function MemberInterviewResultPage({
   result,
@@ -51,7 +52,7 @@ export default function MemberInterviewResultPage({
                   </div>
                   <div>
                     <h1 className="text-2xl font-bold text-white">
-                      면접 결과 리포트
+                      {result.intervieweeNickname}님의 면접 결과
                     </h1>
                     <p className="text-blue-1 text-sm">
                       {/* 멤버 이름 들어갈 곳 */}
@@ -143,7 +144,7 @@ export const getServerSideProps = async (
   }>
 ): Promise<
   GetServerSidePropsResult<{
-    result: TMemberInterviewResult;
+    result: CamelCasedProperties<MemberInterviewResult>;
     user: User | null;
     interviewId: number;
   }>

--- a/apps/client/src/pages/members/interviews/[interviewId].tsx
+++ b/apps/client/src/pages/members/interviews/[interviewId].tsx
@@ -140,7 +140,6 @@ export default function MemberInterviewResultPage({
 export const getServerSideProps = async (
   context: GetServerSidePropsContext<{
     interviewId: string;
-    memberId: string;
   }>
 ): Promise<
   GetServerSidePropsResult<{
@@ -149,12 +148,11 @@ export const getServerSideProps = async (
     interviewId: number;
   }>
 > => {
-  const { interviewId, memberId } = context.params as {
+  const { interviewId } = context.params as {
     interviewId: string;
-    memberId: string;
   };
 
-  if (!interviewId || !memberId || isNaN(Number(interviewId))) {
+  if (!interviewId || isNaN(Number(interviewId))) {
     return { notFound: true };
   }
 

--- a/apps/client/src/shared/errorFallback/index.tsx
+++ b/apps/client/src/shared/errorFallback/index.tsx
@@ -1,0 +1,88 @@
+import { useRouter } from "next/router";
+import { JSX } from "react";
+
+interface ErrorFallbackProps {
+  resetErrorBoundary?: () => void;
+}
+
+export default function ErrorFallback({
+  resetErrorBoundary,
+}: ErrorFallbackProps): JSX.Element {
+  const router = useRouter();
+
+  const handleRefresh = () => {
+    if (resetErrorBoundary) {
+      resetErrorBoundary();
+    } else {
+      window.location.reload();
+    }
+  };
+
+  const handleGoBack = () => {
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      router.push("/");
+    }
+  };
+
+  const handleGoHome = () => {
+    router.push("/");
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-red-50">
+      <div className="text-center max-w-2xl px-8">
+        {/* 에러 아이콘 */}
+        <div className="mb-8">
+          <div className="text-6xl">⚠️</div>
+        </div>
+
+        {/* 에러 제목 */}
+        <h1 className="text-3xl md:text-4xl font-bold mb-4 text-gray-900">
+          오류가 발생했어요 🥲
+        </h1>
+
+        {/* 에러 설명 */}
+        <p className="text-lg md:text-xl mb-6 text-gray-600 leading-relaxed">
+          예상치 못한 문제가 발생했습니다. 페이지를 새로고침하거나 다시
+          시도해주세요.
+        </p>
+
+        {/* 제안 사항 */}
+        <div className="bg-white border border-gray-200 rounded-lg p-6 mb-8 shadow-sm">
+          <p className="text-gray-700 font-medium">
+            페이지를 새로고침하거나 잠시 후 다시 시도해주세요.
+          </p>
+        </div>
+
+        {/* 액션 버튼들 */}
+        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-8">
+          <button
+            onClick={handleGoHome}
+            className="flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg font-medium text-lg transition-colors duration-200 hover:bg-blue-700 min-w-[200px] justify-center"
+          >
+            <span>🏠</span>
+            홈으로 돌아가기
+          </button>
+
+          <button
+            onClick={handleGoBack}
+            className="flex items-center gap-2 px-6 py-3 bg-gray-600 text-white rounded-lg font-medium text-lg transition-colors duration-200 hover:bg-gray-700 min-w-[200px] justify-center"
+          >
+            <span>⬅️</span>
+            이전 페이지로
+          </button>
+
+          <button
+            onClick={handleRefresh}
+            className="flex items-center gap-2 px-6 py-3 bg-green-600 text-white rounded-lg font-medium text-lg transition-colors duration-200 hover:bg-green-700 min-w-[200px] justify-center"
+          >
+            <span>🔄</span>
+            새로고침
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/utils/convertConvention.ts
+++ b/apps/client/src/utils/convertConvention.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+type CamelCase<S extends string> = S extends `${infer T}_${infer U}`
+  ? `${T}${Capitalize<CamelCase<U>>}`
+  : S;
+
+type CamelCasedProperties<T> = {
+  [K in keyof T as K extends string ? CamelCase<K> : K]: T[K] extends object
+    ? T[K] extends Array<any>
+      ? CamelCasedProperties<T[K][number]>[] // 배열 -> 재귀 처리 해줘야함
+      : CamelCasedProperties<T[K]> // 객체 -> 재귀 처리 해줘야함
+    : T[K]; // 기본 타입 -> 그대로 반환
+};
+
+export function mapToCamelCase<T extends object>(
+  obj: T
+): CamelCasedProperties<T> {
+  // 배열이면 재귀 처리
+  if (Array.isArray(obj)) {
+    return obj.map((item) => mapToCamelCase(item)) as CamelCasedProperties<T>;
+  }
+
+  // 객체면 키를 카멜케이스로 변환해서 리턴
+  return Object.keys(obj).reduce((acc, key) => {
+    const camelKey = key.replace(/_([a-z])/g, (_, letter) =>
+      letter.toUpperCase()
+    );
+
+    const value = (obj as any)[key];
+
+    acc[camelKey] =
+      typeof value === "object" && value !== null
+        ? mapToCamelCase(value)
+        : value;
+    return acc;
+  }, {} as any) as CamelCasedProperties<T>;
+}
+
+export type { CamelCasedProperties };

--- a/apps/client/src/utils/date.ts
+++ b/apps/client/src/utils/date.ts
@@ -1,0 +1,9 @@
+const formatDate = (date: string) => {
+  return new Date(date).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "numeric",
+  });
+};
+
+export { formatDate };

--- a/apps/client/src/utils/date.ts
+++ b/apps/client/src/utils/date.ts
@@ -1,7 +1,7 @@
 const formatDate = (date: string) => {
   return new Date(date).toLocaleDateString("ko-KR", {
     year: "numeric",
-    month: "2-digit",
+    month: "long",
     day: "numeric",
   });
 };

--- a/apps/client/src/utils/pagination.ts
+++ b/apps/client/src/utils/pagination.ts
@@ -1,0 +1,26 @@
+export const getVisiblePageNumbers = (
+  currentPage: number,
+  totalPages: number,
+  maxButtons: number
+) => {
+  const pages: number[] = [];
+  const halfMaxButtons = Math.floor(maxButtons / 2);
+
+  let startPage = Math.max(0, currentPage - halfMaxButtons);
+  let endPage = Math.min(totalPages - 1, currentPage + halfMaxButtons);
+
+  // 시작 또는 끝에 도달했을 때 조정
+  if (endPage - startPage < maxButtons - 1) {
+    if (startPage === 0) {
+      endPage = Math.min(totalPages - 1, maxButtons - 1);
+    } else {
+      startPage = Math.max(0, totalPages - maxButtons);
+    }
+  }
+
+  for (let i = startPage; i <= endPage; i++) {
+    pages.push(i);
+  }
+
+  return pages;
+};

--- a/apps/client/src/utils/querykeys.ts
+++ b/apps/client/src/utils/querykeys.ts
@@ -50,11 +50,22 @@ interface MemberRankParams {
 }
 type MemberMethods = {
   rank: (page?: number, size?: number) => QueryKey;
+  interviewsByIdAndPage: (
+    id: number,
+    sort: "asc" | "desc",
+    page?: number
+  ) => QueryKey;
 };
 const memberKeys: QueryKeyFactory<MemberMethods> = {
   all: ["members"] as const,
-  rank: (page: number = 0, size: number = 10): QueryKey =>
-    [...memberKeys.all, "rank", page, size] as const,
+  rank: (page: number = 0): QueryKey =>
+    [...memberKeys.all, "rank", page] as const,
+  interviewsByIdAndPage: (
+    interviewId: number,
+    sort: "asc" | "desc",
+    page: number = 0
+  ): QueryKey =>
+    [...memberKeys.all, "interviews", interviewId, sort, page] as const,
 };
 
 export {

--- a/apps/client/src/utils/rankDisplay.ts
+++ b/apps/client/src/utils/rankDisplay.ts
@@ -1,0 +1,42 @@
+import { Award, Crown, Medal, Trophy } from "lucide-react";
+
+// 랭킹에 따른 아이콘과 색상 결정하는 함수
+const getRankDisplay = (rank: number) => {
+  if (rank === 1) {
+    return { icon: Crown, color: "text-gold-6", bgColor: "bg-gold-1" };
+  } else if (rank <= 3) {
+    return { icon: Medal, color: "text-gold-6", bgColor: "bg-gold-1" };
+  } else if (rank <= 10) {
+    return { icon: Award, color: "text-blue-6", bgColor: "bg-blue-1" };
+  } else {
+    return {
+      icon: Trophy,
+      color: "text-text-tertiary",
+      bgColor: "bg-magenta-1",
+    };
+  }
+};
+
+const getPercentileDisplay = (percentile: number) => {
+  if (percentile >= 90) {
+    return { color: "text-volcano-7", bgColor: "bg-volcano-1" };
+  } else if (percentile >= 70) {
+    return { color: "text-volcano-6", bgColor: "bg-volcano-1" };
+  } else if (percentile >= 60) {
+    return { color: "text-volcano-5", bgColor: "bg-volcano-1" };
+  } else if (percentile >= 50) {
+    return { color: "text-volcano-4", bgColor: "bg-volcano-1" };
+  } else if (percentile >= 40) {
+    return { color: "text-green-7", bgColor: "bg-green-1" };
+  } else if (percentile >= 30) {
+    return { color: "text-green-6", bgColor: "bg-green-1" };
+  } else if (percentile >= 20) {
+    return { color: "text-green-4", bgColor: "bg-green-1" };
+  } else if (percentile >= 10) {
+    return { color: "text-primary", bgColor: "bg-primary-1" };
+  } else {
+    return { color: "text-gold-5", bgColor: "bg-gold-1" };
+  }
+};
+
+export { getRankDisplay, getPercentileDisplay };

--- a/packages/ui/src/components/button/index.tsx
+++ b/packages/ui/src/components/button/index.tsx
@@ -58,6 +58,10 @@ const buttonVariants = cva(
         true: "",
         false: "",
       },
+      optimistic: {
+        true: "",
+        false: "",
+      },
     },
     defaultVariants: {
       variant: "primary",
@@ -110,6 +114,12 @@ const buttonVariants = cva(
         className:
           "bg-gradient-to-r from-error to-error-hover hover:from-error-hover hover:to-error-active",
       },
+      {
+        variant: "glass",
+        optimistic: true,
+        className:
+          "disabled:!bg-volcano-3 disabled:!text-volcano-6 disabled:!opacity-100",
+      },
     ],
   }
 );
@@ -128,6 +138,7 @@ export const Button = ({
   size,
   round = false,
   danger = false,
+  optimistic = false,
   ...props
 }: IButtonProps): JSX.Element => (
   <button
@@ -138,6 +149,7 @@ export const Button = ({
         size,
         round,
         danger,
+        optimistic,
       }),
       className
     )}


### PR DESCRIPTION
## 📌 개요

회원 면접 결과 열람 및 회원 조회 기능 추가와 서버 API 명세에 따른 추가 변경사항들 입니다.

## ✅ 작업 내용

- [x] 회원 면접 결과 열람 UI 및 로직 구현
- [x] 회원 면접들 조회 페이지네이션으로 UI 및 로직 구현
- [x] 유효한 세션ID가 아닐 경우 쿠키 삭제 로직으로 리다리렉트 루프 문제 해결
- [x] 회원 랭킹 및 상위 백분위 조회 기능 추가 

## 🧪 테스트

- [x] 직접 테스트 완료
- [x] 테스트 코드 추가됨 (해당 시)

## 📝 참고 사항

- 없음

## 📎 관련 이슈

Closes #38 
