### PR TITLE
[Fix/#46] - 조회수 요청에 클라이언트 IP를 받기 위한 개선 작업

### DIFF
--- a/apps/client/src/domains/members/api/index.ts
+++ b/apps/client/src/domains/members/api/index.ts
@@ -46,6 +46,7 @@ const getMemberInterviewResult = async (
     .get<MemberInterviewResult>(`/interviews/${interviewId}/result`, {
       headers: {
         cookie: context.req.headers.cookie,
+        "X-Forwarded-For": context.req.headers["x-real-ip"],
       },
     })
     .then((res) => res.data)

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -35,6 +35,8 @@ http {
 
         ssl_protocols       TLSv1.2 TLSv1.3;
         ssl_ciphers         HIGH:!aNULL:!MD5;
+        real_ip_header    X-Forwarded-For;
+        real_ip_recursive on;
 
         location / {
             proxy_pass         http://next-server/;
@@ -42,8 +44,10 @@ http {
             proxy_set_header   Upgrade $http_upgrade;
             proxy_set_header   Connection 'upgrade';
             proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
             proxy_cache_bypass $http_upgrade;
         }
+
     }
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
@@ -53,4 +57,5 @@ http {
 
     sendfile        on;
     keepalive_timeout  65;
+
 }

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -39,6 +39,8 @@ http {
 
         ssl_protocols       TLSv1.2 TLSv1.3;
         ssl_ciphers         HIGH:!aNULL:!MD5;
+        real_ip_header    X-Forwarded-For;
+        real_ip_recursive on;
 
         location / {
             proxy_pass         http://next-server/;
@@ -46,6 +48,7 @@ http {
             proxy_set_header   Upgrade $http_upgrade;
             proxy_set_header   Connection 'upgrade';
             proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
             proxy_cache_bypass $http_upgrade;
         }
     }


### PR DESCRIPTION
## 📌 개요

## ✅ 작업 내용

- [x] Nginx 설정을 변경해서 X-Real-IP 헤더를 받을 수 있도록 설정
- [x] 조회수 집계에 필요한 면접 결과 조회 API 요청에 X-Forwarded-For 헤더 추가

## 🧪 테스트

## 📝 참고 사항

- 없음

## 📎 관련 이슈

Closes #46
