### PR TITLE
[Fix/#50] - 로그인 루프 오류

### DIFF
--- a/apps/client/src/pages/api/auth/logout.ts
+++ b/apps/client/src/pages/api/auth/logout.ts
@@ -1,3 +1,4 @@
+import { clearSessionCookie } from "@/utils/auth";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
@@ -9,11 +10,7 @@ export default async function handler(
   }
 
   try {
-    res.setHeader(
-      "Set-Cookie",
-      "JSESSIONID=; Path=/; Domain=kokomen.kr; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
-    );
-
+    clearSessionCookie(res);
     return res.status(200).json({ message: "Logged out successfully" });
   } catch (error) {
     console.error("Logout error:", error);

--- a/apps/client/src/pages/interviews/index.tsx
+++ b/apps/client/src/pages/interviews/index.tsx
@@ -151,7 +151,6 @@ export const getServerSideProps = async (
         };
       },
       context,
-      authCheck: true,
     }
   );
 };

--- a/apps/client/src/pages/login/index.tsx
+++ b/apps/client/src/pages/login/index.tsx
@@ -1,4 +1,5 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { clearSessionCookieSSR } from "@/utils/auth";
+import { GetServerSidePropsContext } from "next";
 import Head from "next/head";
 import Image from "next/image";
 import { useRouter } from "next/router";
@@ -87,22 +88,13 @@ export default function LoginPage(): JSX.Element {
 }
 
 // 로그인 상태 확인 후 리다이렉트
-export const getServerSideProps: GetServerSideProps = async (
+export const getServerSideProps = async (
   context: GetServerSidePropsContext
 ) => {
   const session = context.req.cookies.JSESSIONID;
 
   if (session) {
-    // 이미 로그인된 상태라면 홈으로 리다이렉트
-    return {
-      redirect: {
-        destination:
-          context.query.redirectTo
-            ?.toString()
-            .replace("localhost", "kokomen.kr") ?? "/",
-        permanent: false,
-      },
-    };
+    clearSessionCookieSSR(context);
   }
 
   return {


### PR DESCRIPTION
## 📌 개요

prod용에서 로그인하면 .kokomen.kr로 도메인이 설정되는데, 쿠키가 dev 서버에도 영향을 미쳐서 dev 서버에는 로그인 되어있지 않아 401 에러로 로그인 페이지로 리다이렉트 시키는데, 로그인에서는 sessionId가 있으면 다시 메인으로 돌아가기 때문에 루프되는 현상이 있었습니다.

기존의 쿠키 삭제 로직의 경우 .kokomen.kr로 쿠키의 도메인이 설정되어 있기 때문에 서브 도메인의 서버에서는 이를 제대로 처리할 수 없기 때문에 제대로 처리하지 못했습니다. 따라서 set header로 무력화시켜도 도메인을 따로 명시하지 않아서 지워지지 않는 현상때문에 해당 문제가 지속되었습니다.

이를 해결하는 과정에서 기존의 복잡한 로그아웃 분기 처리 과정을 없애고 차라리 로그인 페이지로 리다이렉트되었을 경우 기존의 로그인 쿠키를 삭제하는 방식으로 하였고, 쿠키 삭제의 경우는 SSR과 서버 핸들러 전용 헬퍼 함수를 따로 만들어 추가했습니다.

## ✅ 작업 내용

- [x] 쿠키 삭제 헬퍼 함수 추가
- [x] 로그인 페이지에서 쿠키 삭제 로직 추가

## 🧪 테스트

- [x] 직접 테스트 완료

## 📝 참고 사항

- 없음

## 📎 관련 이슈

Closes #50 
