### PR TITLE
[Feat/#48] - posthog 모니터링 커스텀 이벤트 추가

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.9.0",
     "lucide-react": "^0.511.0",
     "next": "15.3.2",
+    "posthog-js": "^1.257.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.59.0",

--- a/apps/client/src/domains/auth/components/profilesettingForm.tsx
+++ b/apps/client/src/domains/auth/components/profilesettingForm.tsx
@@ -9,6 +9,7 @@ import z from "zod";
 import { updateUserProfile } from "@/domains/auth/api";
 import { Input } from "@kokomen/ui/components/input";
 import { Button } from "@kokomen/ui/components/button";
+import { captureFormSubmitEvent } from "@/utils/analytics";
 
 // eslint-disable-next-line @rushstack/typedef-var
 const ProfileSetting = z.object({
@@ -48,6 +49,14 @@ export default function ProfileSettingForm({
     isSuccess,
   } = useMutation({
     mutationFn: updateUserProfile,
+    onMutate: (nickname) => {
+      captureFormSubmitEvent({
+        name: "changeNickname",
+        properties: {
+          nickname: nickname,
+        },
+      });
+    },
     onSuccess: () => {
       router.replace(redirectTo ?? "/");
     },

--- a/apps/client/src/domains/interview/components/interviewInput.tsx
+++ b/apps/client/src/domains/interview/components/interviewInput.tsx
@@ -1,6 +1,7 @@
 import { submitInterviewAnswer } from "@/domains/interview/api/interviewAnswer";
 import { Interview } from "@/domains/interview/types";
 import { useSpeechRecognition } from "@/hooks/useSpeechRecognition";
+import { captureFormSubmitEvent } from "@/utils/analytics";
 import { Button } from "@kokomen/ui/components/button";
 import { Textarea } from "@kokomen/ui/components/textarea/textarea";
 import { useMutation } from "@tanstack/react-query";
@@ -54,7 +55,15 @@ export function InterviewAnswerInput({
   const router = useRouter();
   const { mutate, isPending } = useMutation({
     mutationFn: submitInterviewAnswer,
-    onMutate: () => {
+    onMutate: (data) => {
+      captureFormSubmitEvent({
+        name: "submitInterviewAnswer",
+        properties: {
+          question: cur_question,
+          answer: data.answer,
+          question_id: data.questionId,
+        },
+      });
       const previousMessage = {
         prevMessage: cur_question,
         prevQuestionId: cur_question_id,

--- a/apps/client/src/domains/interview/hooks/useInterviewCreateMutation.ts
+++ b/apps/client/src/domains/interview/hooks/useInterviewCreateMutation.ts
@@ -3,6 +3,7 @@ import { useToast } from "@kokomen/ui/hooks/useToast";
 import { useMutation } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 import { startNewInterview } from "../api";
+import { captureFormSubmitEvent } from "@/utils/analytics";
 
 const useInterviewCreateMutation = () => {
   const router = useRouter();
@@ -10,6 +11,15 @@ const useInterviewCreateMutation = () => {
 
   return useMutation({
     mutationFn: startNewInterview,
+    onMutate: (data) => {
+      captureFormSubmitEvent({
+        name: "startNewInterview",
+        properties: {
+          category: data.category,
+          questionCount: data.max_question_count,
+        },
+      });
+    },
     onSuccess: (data) => {
       router.push({
         pathname: `/interviews/${data.interview_id}`,

--- a/apps/client/src/domains/members/components/memberInterviewHistory.tsx
+++ b/apps/client/src/domains/members/components/memberInterviewHistory.tsx
@@ -17,6 +17,7 @@ import { useRouter } from "next/router";
 import { formatDate } from "@/utils/date";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { getVisiblePageNumbers } from "@/utils/pagination";
+import { captureButtonEvent } from "@/utils/analytics";
 
 export default function InterviewHistory({
   memberId,
@@ -108,6 +109,16 @@ export default function InterviewHistory({
 
                   <div className="md:ml-4 md:w-auto w-full">
                     <Link
+                      onClick={() => {
+                        captureButtonEvent({
+                          name: "MembersInterveiw",
+                          properties: {
+                            interviewId: interview.interviewId,
+                            category: interview.interviewCategory,
+                            question: interview.rootQuestion,
+                          },
+                        });
+                      }}
                       href={`/members/interviews/${interview.interviewId}`}
                       className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-blue-600 bg-blue-50 hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
                     >

--- a/apps/client/src/domains/members/components/memberQuestionFeedback.tsx
+++ b/apps/client/src/domains/members/components/memberQuestionFeedback.tsx
@@ -7,6 +7,7 @@ import { Button } from "@kokomen/ui/components/button";
 import { toggleMemberInterviewAnswerLike } from "@/domains/members/api";
 import { CamelCasedProperties } from "@/utils/convertConvention";
 import { MemberInterviewResult } from "@/domains/members/types";
+import { captureButtonEvent } from "@/utils/analytics";
 
 export default function MemberQuestionFeedback({
   questionAndFeedback,
@@ -24,7 +25,15 @@ export default function MemberQuestionFeedback({
   const { mutate: toggleInterviewLikeMutation, isPending } = useMutation({
     mutationFn: (liked: boolean) =>
       toggleMemberInterviewAnswerLike(liked, questionAndFeedback.answerId),
-    onMutate: () => {
+    onMutate: (data) => {
+      captureButtonEvent({
+        name: "MemberInterviewLike",
+        properties: {
+          type: "answer",
+          likedAnswerId: questionAndFeedback.answerId,
+          liked: data,
+        },
+      });
       setAnswerLiked(!answerLiked);
     },
     onError: (error) => {

--- a/apps/client/src/domains/members/components/memberTotalFeedback.tsx
+++ b/apps/client/src/domains/members/components/memberTotalFeedback.tsx
@@ -7,6 +7,7 @@ import { isAxiosError } from "axios";
 import { Button } from "@kokomen/ui/components/button";
 import { MemberInterviewResult } from "@/domains/members/types";
 import { CamelCasedProperties } from "@/utils/convertConvention";
+import { captureButtonEvent } from "@/utils/analytics";
 
 export default function MemberTotalFeedback({
   result,
@@ -25,6 +26,14 @@ export default function MemberTotalFeedback({
     mutationFn: (liked: boolean) =>
       toggleMemberInterviewLike(liked, interviewId),
     onMutate: () => {
+      captureButtonEvent({
+        name: "MemberInterviewLike",
+        properties: {
+          type: "interview",
+          likedInterviewId: interviewId,
+          liked: !isTotalLikedIncludesMine,
+        },
+      });
       setIsTotalLikedIncludesMine(!isTotalLikedIncludesMine);
       setTotalLikedCount(
         isTotalLikedIncludesMine ? totalLikedCount - 1 : totalLikedCount + 1

--- a/apps/client/src/domains/members/components/rankCard.tsx
+++ b/apps/client/src/domains/members/components/rankCard.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 import { Button } from "@kokomen/ui/components/button";
 import { JSX } from "react";
+import { captureButtonEvent } from "@/utils/analytics";
 
 export default function RankCard(): JSX.Element {
   const { data } = useQuery({
@@ -24,7 +25,16 @@ export default function RankCard(): JSX.Element {
           role="button"
           name={`rank-card-${rank.id}-${rank.nickname}`}
           aria-label={`rank-card-${rank.id}-${rank.nickname}`}
-          onClick={() => router.push(`/members/${rank.id}`)}
+          onClick={() => {
+            captureButtonEvent({
+              name: "MemberDashboard",
+              properties: {
+                rank: rank.id,
+                nickname: rank.nickname,
+              },
+            });
+            router.push(`/members/${rank.id}`);
+          }}
         >
           <div className="flex items-center gap-4">
             <div className="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-primary  text-white font-bold text-lg">

--- a/apps/client/src/hooks/useLogout.ts
+++ b/apps/client/src/hooks/useLogout.ts
@@ -1,10 +1,16 @@
 import { logout } from "@/domains/auth/api";
+import { captureButtonEvent } from "@/utils/analytics";
 import { useMutation } from "@tanstack/react-query";
 import { useCallback } from "react";
 
 export const useLogout = () => {
   const logoutMutation = useMutation({
     mutationFn: logout,
+    onMutate: () => {
+      captureButtonEvent({
+        name: "userLogout",
+      });
+    },
     onSuccess: () => {
       window.location.href = "/";
     },

--- a/apps/client/src/instrumentation-client.ts
+++ b/apps/client/src/instrumentation-client.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import posthog from "posthog-js";
 
 Sentry.init({
   dsn: "https://e7480fc746e8c3eb39088e28c6550b5c@o4509558780395520.ingest.us.sentry.io/4509558781247488",
@@ -28,3 +29,9 @@ Sentry.init({
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
+  api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  defaults: "2025-05-24",
+  autocapture: false,
+});

--- a/apps/client/src/pages/dashboard/index.tsx
+++ b/apps/client/src/pages/dashboard/index.tsx
@@ -143,6 +143,6 @@ export const getServerSideProps = async (
         },
       };
     },
-    { authCheck: true, context }
+    { context }
   );
 };

--- a/apps/client/src/utils/analytics.ts
+++ b/apps/client/src/utils/analytics.ts
@@ -1,0 +1,41 @@
+import posthog, { CaptureResult } from "posthog-js";
+
+interface CaptureEventProperties<
+  TEvent extends string,
+  TProperties extends Record<string, string>,
+> {
+  name: TEvent;
+  properties?: TProperties;
+}
+
+type ButtonCaptureEvent =
+  | "userLogout"
+  | "MembersInterveiw"
+  | "MemberInterviewLike"
+  | "MemberDashboard";
+function captureButtonEvent({
+  name,
+  properties,
+}: CaptureEventProperties<ButtonCaptureEvent, {}>): CaptureResult | undefined {
+  return posthog.capture("button clicked", {
+    name,
+    ...properties,
+  });
+}
+
+type FormSubmitEvent =
+  | "logout"
+  | "startNewInterview"
+  | "submitInterviewAnswer"
+  | "changeNickname";
+function captureFormSubmitEvent({
+  name,
+  properties,
+}: CaptureEventProperties<FormSubmitEvent, {}>): CaptureResult | undefined {
+  return posthog.capture("survey sent", {
+    name,
+    ...properties,
+  });
+}
+
+export { captureButtonEvent, captureFormSubmitEvent };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,6 +2488,7 @@ __metadata:
     lucide-react: "npm:^0.511.0"
     msw: "npm:^2.10.2"
     next: "npm:15.3.2"
+    posthog-js: "npm:^1.257.0"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     react-hook-form: "npm:^7.59.0"
@@ -6967,6 +6968,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.38.1":
+  version: 3.44.0
+  resolution: "core-js@npm:3.44.0"
+  checksum: 10c0/759bf3dc5f75068e9425dddf895fd5531c38794a11ea1c2b65e5ef7c527fe3652d59e8c287e574a211af9bab3c057c5c3fa6f6a773f4e142af895106efad38a4
+  languageName: node
+  linkType: hard
+
 "create-require@npm:^1.1.0":
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
@@ -8358,6 +8366,13 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/45b559cff889934ebb8bc498351e5acba40750ada7e7d6bde197768d2fa67c149be8ae7f8ff34d03f4e1eb20f2764116e56440aaa2f6689e9a4aa7ef06acafe9
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.4.8":
+  version: 0.4.8
+  resolution: "fflate@npm:0.4.8"
+  checksum: 10c0/29d1eddaaa5deab61b1c6b0d21282adacadbc4d2c01e94d8b1ee784398151673b9c563e53f97a801bc410a1ae55e8de5378114a743430e643e7a0644ba8e5a42
   languageName: node
   linkType: hard
 
@@ -11900,10 +11915,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"posthog-js@npm:^1.257.0":
+  version: 1.257.0
+  resolution: "posthog-js@npm:1.257.0"
+  dependencies:
+    core-js: "npm:^3.38.1"
+    fflate: "npm:^0.4.8"
+    preact: "npm:^10.19.3"
+    web-vitals: "npm:^4.2.4"
+  peerDependencies:
+    "@rrweb/types": 2.0.0-alpha.17
+    rrweb-snapshot: 2.0.0-alpha.17
+  peerDependenciesMeta:
+    "@rrweb/types":
+      optional: true
+    rrweb-snapshot:
+      optional: true
+  checksum: 10c0/a2471791a6c0ae1fb10ccc36941c111c3e63ca06202d74e727627c887a15c48f1b0d3c177884c49b8fad56148b499ab91e2064baf184e0957af982696096eb59
+  languageName: node
+  linkType: hard
+
 "potpack@npm:^1.0.1":
   version: 1.0.2
   resolution: "potpack@npm:1.0.2"
   checksum: 10c0/670c23898a4257130858b960c2e654d3327c0f6a7e7091ff5846f213e65af8f9476320b995b8ad561a47a4d1c359c7ef347de57d22e7b02597051abb52bc85c4
+  languageName: node
+  linkType: hard
+
+"preact@npm:^10.19.3":
+  version: 10.26.9
+  resolution: "preact@npm:10.26.9"
+  checksum: 10c0/15f187e3278ae749b70e887f88bb01be63ebcc2eea46ffa86be69180716db40b8b4304e9768767fd68a5910ef5fd1f9ea6389e17cd25e950be76574d568e8fc3
   languageName: node
   linkType: hard
 
@@ -14560,6 +14602,13 @@ __metadata:
   dependencies:
     makeerror: "npm:1.0.12"
   checksum: 10c0/a17e037bccd3ca8a25a80cb850903facdfed0de4864bd8728f1782370715d679fa72e0a0f5da7c1c1379365159901e5935f35be531229da53bbfc0efdabdb48e
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:^4.2.4":
+  version: 4.2.4
+  resolution: "web-vitals@npm:4.2.4"
+  checksum: 10c0/383c9281d5b556bcd190fde3c823aeb005bb8cf82e62c75b47beb411014a4ed13fa5c5e0489ed0f1b8d501cd66b0bebcb8624c1a75750bd5df13e2a3b1b2d194
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📌 개요

posthog 모니터링에 대해서 클릭 및 페이지 이동, 폼 제출 등에 대한 커스텀 이벤트를 정의한 PR입니다.

## ✅ 작업 내용

- [x] 모니터링 헬퍼 함수 추가
- [x] 모니터링 Initialize 추가(autocapture disabled)

## 🧪 테스트

- [x] 직접 테스트 완료

## 📝 참고 사항

- 없음

## 📎 관련 이슈

Closes #48 
