### PR TITLE
[Feat/#59] - 인터뷰에 대한 메모 기능 구현

### DIFF
--- a/apps/client/__tests__/myInterviewResultPage.test.tsx
+++ b/apps/client/__tests__/myInterviewResultPage.test.tsx
@@ -1,0 +1,230 @@
+import { InterviewReport } from "@/domains/interviewReport/types";
+import { server } from "@/mocks";
+import MyInterviewResultPage from "@/pages/interviews/[interviewId]/result";
+import { renderWithProviders } from "@/utils/test-utils";
+import { fireEvent, screen, waitFor } from "@testing-library/dom";
+import { http, HttpResponse } from "msw";
+
+const myInterviewResultData: InterviewReport = {
+  feedbacks: [
+    {
+      question_id: 1,
+      answer_id: 1,
+      question: "자기소개를 해주세요.",
+      answer:
+        "안녕하세요. 저는 3년차 프론트엔드 개발자입니다. React와 TypeScript를 주로 사용하며, 사용자 경험을 중시하는 개발자입니다.",
+      answer_rank: "A",
+      answer_feedback:
+        "명확하고 간결한 자기소개로 좋은 첫인상을 주었습니다. 기술 스택과 개발 철학을 잘 어필했습니다.",
+      submitted_answer_memo_content: "작성된 메모",
+      temp_answer_memo_content: "임시작성 메모",
+      answer_memo_visibility: "PUBLIC",
+    },
+  ],
+  total_feedback:
+    "전반적으로 기술적 역량과 협업 능력이 균형있게 발달한 개발자로 보입니다. 구체적인 경험과 성과를 바탕으로 답변하여 신뢰도가 높습니다. 향후 더 큰 규모의 프로젝트에서 리더십을 발휘할 수 있을 것으로 기대됩니다.",
+  total_score: 85,
+  user_cur_score: 85,
+  user_prev_score: 80,
+  user_cur_rank: "A",
+  user_prev_rank: "B",
+};
+
+describe("내 면접결과 페이지 테스트", () => {
+  it("내 면접결과 페이지 렌더링 테스트", async () => {
+    renderWithProviders(
+      <MyInterviewResultPage report={myInterviewResultData} userInfo={null} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("내 면접결과 메모 테스트", () => {
+  it("메모가 제대로 렌더링 되는지 테스트", async () => {
+    renderWithProviders(
+      <MyInterviewResultPage report={myInterviewResultData} userInfo={null} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+    const answerFeedbackButton = screen.getByText("자기소개를 해주세요.");
+    fireEvent.click(answerFeedbackButton);
+    await waitFor(() => {
+      expect(screen.getByText("작성된 메모")).toBeInTheDocument();
+    });
+  });
+
+  it("임시 작성한 메모가 있을 때 모달이 렌더링 되는지 테스트", async () => {
+    renderWithProviders(
+      <MyInterviewResultPage report={myInterviewResultData} userInfo={null} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+    const answerFeedbackButton = screen.getByText("자기소개를 해주세요.");
+    fireEvent.click(answerFeedbackButton);
+    const memoEditButton = screen.getByRole("button", {
+      name: "메모 편집하기",
+    });
+    fireEvent.click(memoEditButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText("임시 작성중인 메모가 있습니다. 메모를 불러올까요?")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: "새로쓰기",
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: "이어서 작성",
+        })
+      ).toBeInTheDocument();
+    });
+  });
+  it("임시 작성한 메모가 있을 때 새로쓰기 버튼을 눌렀을 때 모달이 닫히고 메모가 임시저장한 값으로 변경 되는지 테스트", async () => {
+    renderWithProviders(
+      <MyInterviewResultPage report={myInterviewResultData} userInfo={null} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+    const answerFeedbackButton = screen.getByText("자기소개를 해주세요.");
+    fireEvent.click(answerFeedbackButton);
+    const memoEditButton = screen.getByRole("button", {
+      name: "메모 편집하기",
+    });
+    fireEvent.click(memoEditButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText("임시 작성중인 메모가 있습니다. 메모를 불러올까요?")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: "이어서 작성",
+        })
+      ).toBeInTheDocument();
+    });
+
+    const continueMemoButton = screen.getByRole("button", {
+      name: "이어서 작성",
+    });
+    fireEvent.click(continueMemoButton);
+    await waitFor(() => {
+      expect(screen.getByText("임시작성 메모")).toBeInTheDocument();
+    });
+  });
+  it("메모 삭제 버튼을 눌렀을 때 모달이 렌더링 되는지 테스트", async () => {
+    renderWithProviders(
+      <MyInterviewResultPage report={myInterviewResultData} userInfo={null} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+    const answerFeedbackButton = screen.getByText("자기소개를 해주세요.");
+    fireEvent.click(answerFeedbackButton);
+    const memoEditButton = screen.getByRole("button", {
+      name: "메모 삭제하기",
+    });
+    fireEvent.click(memoEditButton);
+  });
+
+  it("메모 삭제 버튼을 눌렀을 때 정상적으로 API 요청과 응답이 오는지 확인", async () => {
+    const deleteCalled = jest.fn();
+    server.use(
+      http.delete(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/answers/1/memo`,
+        () => {
+          deleteCalled();
+          return HttpResponse.json({
+            message: "메모 삭제 성공",
+          });
+        }
+      )
+    );
+    renderWithProviders(
+      <MyInterviewResultPage report={myInterviewResultData} userInfo={null} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+    const answerFeedbackButton = screen.getByText("자기소개를 해주세요.");
+    fireEvent.click(answerFeedbackButton);
+    const memoEditButton = screen.getByRole("button", {
+      name: "메모 삭제하기",
+    });
+    fireEvent.click(memoEditButton);
+    const deleteButton = screen.getByRole("button", {
+      name: "삭제하기",
+    });
+    fireEvent.click(deleteButton);
+    await waitFor(() => {
+      expect(deleteCalled).toHaveBeenCalled();
+      expect(screen.queryByText("작성된 메모")).not.toBeInTheDocument();
+    });
+  });
+
+  it("임시 저장중인 메모를 작성하고 저장 버튼을 눌렀을 때 정상적으로 API 요청과 응답이 오는지 확인", async () => {
+    let requestBody: any;
+    server.use(
+      http.post(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/answers/1/memo`,
+        async (req) => {
+          // 요청 본문 파싱
+          requestBody = await req.request.json();
+
+          return HttpResponse.json({
+            message: "메모 저장 성공",
+          });
+        }
+      )
+    );
+
+    renderWithProviders(
+      <MyInterviewResultPage report={myInterviewResultData} userInfo={null} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("자기소개를 해주세요.")).toBeInTheDocument();
+    });
+
+    const answerFeedbackButton = screen.getByText("자기소개를 해주세요.");
+    fireEvent.click(answerFeedbackButton);
+
+    const memoEditButton = screen.getByRole("button", {
+      name: "메모 편집하기",
+    });
+    fireEvent.click(memoEditButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("임시 작성중인 메모가 있습니다. 메모를 불러올까요?")
+      ).toBeInTheDocument();
+    });
+
+    const continueMemoButton = screen.getByRole("button", {
+      name: "이어서 작성",
+    });
+    fireEvent.click(continueMemoButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("임시작성 메모")).toBeInTheDocument();
+    });
+
+    const saveMemoButton = screen.getByRole("button", {
+      name: "저장",
+    });
+    fireEvent.click(saveMemoButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("임시작성 메모")).toBeInTheDocument();
+    });
+
+    expect(requestBody).toBeDefined();
+    expect(requestBody.content).toEqual("임시작성 메모");
+    expect(requestBody.visibility).toBe("PUBLIC");
+  });
+});

--- a/apps/client/__tests__/myInterviewResultPage.test.tsx
+++ b/apps/client/__tests__/myInterviewResultPage.test.tsx
@@ -168,14 +168,12 @@ describe("내 면접결과 메모 테스트", () => {
   });
 
   it("임시 저장중인 메모를 작성하고 저장 버튼을 눌렀을 때 정상적으로 API 요청과 응답이 오는지 확인", async () => {
-    let requestBody: any;
+    const saveCalled = jest.fn();
     server.use(
-      http.post(
+      http.patch(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/answers/1/memo`,
-        async (req) => {
-          // 요청 본문 파싱
-          requestBody = await req.request.json();
-
+        async () => {
+          saveCalled();
           return HttpResponse.json({
             message: "메모 저장 성공",
           });
@@ -222,9 +220,6 @@ describe("내 면접결과 메모 테스트", () => {
     await waitFor(() => {
       expect(screen.getByText("임시작성 메모")).toBeInTheDocument();
     });
-
-    expect(requestBody).toBeDefined();
-    expect(requestBody.content).toEqual("임시작성 메모");
-    expect(requestBody.visibility).toBe("PUBLIC");
+    expect(saveCalled).toHaveBeenCalled();
   });
 });

--- a/apps/client/__tests__/profileSetting.test.tsx
+++ b/apps/client/__tests__/profileSetting.test.tsx
@@ -39,6 +39,8 @@ describe("profile setting 렌더링 테스트", () => {
           score: 0,
           token_count: 10,
           profile_completed: false,
+          total_member_count: 10,
+          rank: 1,
         }}
       />
     );
@@ -68,6 +70,8 @@ describe("profile setting 기능 테스트", () => {
           score: 0,
           token_count: 10,
           profile_completed: false,
+          total_member_count: 10,
+          rank: 1,
         }}
       />
     );
@@ -102,6 +106,8 @@ describe("profile setting 기능 테스트", () => {
           score: 0,
           token_count: 10,
           profile_completed: false,
+          total_member_count: 10,
+          rank: 1,
         }}
       />
     );
@@ -128,6 +134,8 @@ describe("profile setting 기능 테스트", () => {
           score: 0,
           token_count: 10,
           profile_completed: false,
+          total_member_count: 10,
+          rank: 1,
         }}
       />
     );

--- a/apps/client/src/domains/dashboard/components/interviewHistory.tsx
+++ b/apps/client/src/domains/dashboard/components/interviewHistory.tsx
@@ -3,7 +3,15 @@ import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import { interviewHistoryKeys } from "@/utils/querykeys";
 import Select from "@kokomen/ui/components/select";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { Calendar, Clock, Eye, Heart, TrendingUp, Trophy } from "lucide-react";
+import {
+  Calendar,
+  Clock,
+  Eye,
+  Heart,
+  NotebookPen,
+  TrendingUp,
+  Trophy,
+} from "lucide-react";
 import Link from "next/link";
 import { useCallback, useRef, useState } from "react";
 
@@ -164,8 +172,14 @@ export default function InterviewHistory() {
                       {interview.cur_answer_count}/
                       {interview.max_question_count}문제
                     </div>
-                    {interview.score && (
-                      <div className="flex items-center gap-1">
+                    {interview.interview_state === "FINISHED" && (
+                      <div
+                        className={`flex items-center gap-1 ${
+                          interview.score > 0
+                            ? "text-green-6"
+                            : "text-volcano-6"
+                        }`}
+                      >
                         <TrendingUp className="w-4 h-4" />
                         {interview.score}점
                       </div>
@@ -176,9 +190,25 @@ export default function InterviewHistory() {
                           <Eye className="w-4 h-4" />
                           {interview.interview_view_count}
                         </div>
-                        <div className="flex items-center gap-1">
+                        <div
+                          className={`flex items-center gap-1 ${
+                            interview.interview_already_liked
+                              ? "text-volcano-6"
+                              : "text-gray-400"
+                          }`}
+                        >
                           <Heart className="w-4 h-4" />
                           {interview.interview_like_count}
+                        </div>
+                        <div
+                          className={`flex items-center gap-1 ${
+                            interview.submitted_answer_memo_count > 0
+                              ? "text-gold-6"
+                              : "text-gray-400"
+                          }`}
+                        >
+                          <NotebookPen className="w-4 h-4" />
+                          {interview.submitted_answer_memo_count}
                         </div>
                       </>
                     )}

--- a/apps/client/src/domains/dashboard/types/index.ts
+++ b/apps/client/src/domains/dashboard/types/index.ts
@@ -9,6 +9,9 @@ type InterviewHistory = {
   score: number;
   interview_view_count: number;
   interview_like_count: number;
+  interview_already_liked: boolean;
+  submitted_answer_memo_count: number;
+  has_temp_answer_memo: boolean;
 };
 
 export type { InterviewHistory };

--- a/apps/client/src/domains/interviewReport/api/answerMemo.ts
+++ b/apps/client/src/domains/interviewReport/api/answerMemo.ts
@@ -20,7 +20,10 @@ const updateAnswerMemo = async (
   answerId: number,
   memo: AnswerMemo
 ): Promise<AxiosResponse> => {
-  return answerMemoApiInstance.put(`/${answerId}/memo`, { memo });
+  return answerMemoApiInstance.patch(`/${answerId}/memo`, {
+    content: memo.content,
+    visibility: memo.visibility,
+  });
 };
 
 const deleteAnswerMemo = async (answerId: number): Promise<AxiosResponse> => {

--- a/apps/client/src/domains/interviewReport/api/answerMemo.ts
+++ b/apps/client/src/domains/interviewReport/api/answerMemo.ts
@@ -1,0 +1,30 @@
+import { AnswerMemo } from "@/domains/interviewReport/types/memo";
+import axios, { AxiosInstance, AxiosResponse } from "axios";
+
+const answerMemoApiInstance: AxiosInstance = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}/answers`,
+  withCredentials: true,
+});
+
+const createNewAnswerMemo = async (
+  answerId: number,
+  memo: AnswerMemo
+): Promise<AxiosResponse> => {
+  return answerMemoApiInstance.post(`/${answerId}/memo`, {
+    content: memo.content,
+    visibility: memo.visibility,
+  });
+};
+
+const updateAnswerMemo = async (
+  answerId: number,
+  memo: AnswerMemo
+): Promise<AxiosResponse> => {
+  return answerMemoApiInstance.put(`/${answerId}/memo`, { memo });
+};
+
+const deleteAnswerMemo = async (answerId: number): Promise<AxiosResponse> => {
+  return answerMemoApiInstance.delete(`/${answerId}/memo`);
+};
+
+export { createNewAnswerMemo, updateAnswerMemo, deleteAnswerMemo };

--- a/apps/client/src/domains/interviewReport/components/answerMemo.tsx
+++ b/apps/client/src/domains/interviewReport/components/answerMemo.tsx
@@ -1,0 +1,301 @@
+import { Button } from "@kokomen/ui/components/button";
+import { NotebookPen, Trash } from "lucide-react";
+import { Dispatch, JSX, SetStateAction, useState } from "react";
+import { Textarea } from "@kokomen/ui/components/textarea/textarea";
+import { useMutation } from "@tanstack/react-query";
+import {
+  createNewAnswerMemo,
+  deleteAnswerMemo,
+} from "@/domains/interviewReport/api/answerMemo";
+import { AnswerMemo } from "@/domains/interviewReport/types/memo";
+import { useToast } from "@kokomen/ui/hooks/useToast";
+import { isAxiosError } from "axios";
+import { Modal } from "@kokomen/ui/components/modal";
+import { useForm } from "react-hook-form";
+import { Radio, RadioGroup } from "@kokomen/ui/components/radio";
+import z from "zod";
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { useModal } from "@/hooks/useModal";
+
+export default function AnswerMemoComponent({
+  answerId,
+  tempMemo,
+  visibility,
+  answerMemoProp,
+}: {
+  answerId: number;
+  tempMemo: string;
+  visibility: "PUBLIC" | "PRIVATE" | "FRIENDS";
+  answerMemoProp: string;
+}): JSX.Element {
+  const [isMemoEditOpen, setIsMemoEditOpen] = useState(false);
+  const {
+    isOpen: isMemoDeleteModalOpen,
+    openModal: openMemoDeleteModal,
+    toggleModal: toggleMemoDeleteModal,
+  } = useModal();
+  const [isTempMemoModalOpen, setIsTempMemoModalOpen] = useState(false);
+  const [answerMemo, setAnswerMemo] = useState<string>(answerMemoProp);
+
+  const handleMemoEditButtonClick = (): void => {
+    if (tempMemo) {
+      setIsTempMemoModalOpen(true);
+    } else {
+      setIsMemoEditOpen(true);
+    }
+  };
+  if (isMemoEditOpen)
+    return (
+      <AnswerMemoEdit
+        answerId={answerId}
+        answerMemo={answerMemo}
+        visibility={visibility}
+        setAnswerMemo={setAnswerMemo}
+        setIsMemoEditOpen={setIsMemoEditOpen}
+      />
+    );
+  return (
+    <>
+      {answerMemo ? (
+        <div className="flex flex-col gap-4">
+          <div className="flex gap-2">
+            <Button variant={"glass"} onClick={handleMemoEditButtonClick}>
+              <NotebookPen />
+              메모 편집하기
+            </Button>
+            <Button variant={"warning"} onClick={openMemoDeleteModal}>
+              <Trash />
+              메모 삭제하기
+            </Button>
+          </div>
+          <p className="border border-border-secondary p-4 rounded-lg">
+            {answerMemo}
+          </p>
+        </div>
+      ) : (
+        <div className="border border-border-secondary p-4 rounded-lg flex justify-between items-center">
+          <p>보완이 필요하거나 학습한 내용을 메모해 보세요.</p>
+          <Button
+            variant={"glass"}
+            onClick={handleMemoEditButtonClick}
+            disabled={isMemoEditOpen}
+          >
+            <NotebookPen /> 메모 작성하기
+          </Button>
+        </div>
+      )}
+      {isMemoDeleteModalOpen && (
+        <AnswerMemoDeleteModal
+          answerId={answerId}
+          setAnswerMemo={setAnswerMemo}
+          isMemoDeleteModalOpen={isMemoDeleteModalOpen}
+          toggleModal={toggleMemoDeleteModal}
+        />
+      )}
+
+      {isTempMemoModalOpen && (
+        <Modal
+          isOpen={isTempMemoModalOpen}
+          onClose={() => setIsTempMemoModalOpen(false)}
+          title="임시 메모 작성"
+        >
+          <div>
+            <p>임시 작성중인 메모가 있습니다. 메모를 불러올까요?</p>
+            <div>
+              <Button
+                type="button"
+                variant={"warning"}
+                onClick={() => {
+                  setIsTempMemoModalOpen(false);
+                  setIsMemoEditOpen(true);
+                }}
+              >
+                새로쓰기
+              </Button>
+              <Button
+                type="button"
+                variant={"success"}
+                onClick={() => {
+                  setAnswerMemo(tempMemo);
+                  setIsMemoEditOpen(true);
+                }}
+              >
+                이어서 작성
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+function AnswerMemoDeleteModal({
+  answerId,
+  setAnswerMemo,
+  isMemoDeleteModalOpen,
+  toggleModal,
+}: {
+  answerId: number;
+  setAnswerMemo: Dispatch<SetStateAction<string>>;
+  isMemoDeleteModalOpen: boolean;
+  toggleModal: () => void;
+}): JSX.Element {
+  const { error: errorToast } = useToast();
+  const { mutate: deleteAnswerMemoMutate } = useMutation({
+    mutationFn: () => deleteAnswerMemo(answerId),
+    onMutate: () => {
+      toggleModal();
+      setAnswerMemo("");
+    },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        errorToast({
+          title: "메모 삭제 실패",
+          description:
+            error.response?.data.message || "메모 삭제에 실패했습니다.",
+        });
+      } else {
+        errorToast({
+          title: "메모 삭제 실패",
+          description:
+            "서버 오류가 발생하여 메모 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+        });
+      }
+    },
+  });
+  return (
+    <Modal
+      isOpen={isMemoDeleteModalOpen}
+      onClose={toggleModal}
+      title="메모 삭제"
+    >
+      <p className="text-xl mb-5 text-center">
+        메모를 삭제하시겠습니까? <br /> 삭제 후 복구가 불가능합니다.
+      </p>
+      <div className="grid grid-cols-2 gap-2 font-bold">
+        <Button
+          type="button"
+          variant={"default"}
+          size={"large"}
+          onClick={toggleModal}
+        >
+          취소
+        </Button>
+        <Button
+          type="button"
+          size={"large"}
+          variant={"warning"}
+          onClick={() => deleteAnswerMemoMutate()}
+        >
+          삭제하기
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+const answerMemoSchema = z.object({
+  content: z.string({ message: "메모를 입력해주세요." }),
+  visibility: z.enum(["PUBLIC", "PRIVATE"]),
+});
+
+function AnswerMemoEdit({
+  answerId,
+  answerMemo,
+  visibility,
+  setAnswerMemo,
+  setIsMemoEditOpen,
+}: {
+  answerId: number;
+  answerMemo: string;
+  visibility: AnswerMemo["visibility"];
+  setAnswerMemo: Dispatch<SetStateAction<string>>;
+  setIsMemoEditOpen: Dispatch<SetStateAction<boolean>>;
+}): JSX.Element {
+  const { error: errorToast } = useToast();
+  const {
+    handleSubmit,
+    setValue,
+    formState: { errors: answerMemoFormErrors },
+    watch,
+  } = useForm<z.infer<typeof answerMemoSchema>>({
+    defaultValues: {
+      content: answerMemo,
+      visibility: (visibility ?? "PUBLIC") as "PUBLIC" | "PRIVATE",
+    },
+    resolver: standardSchemaResolver(answerMemoSchema),
+  });
+
+  const { mutate: createNewAnswerMemoMutate } = useMutation({
+    mutationFn: (answerMemo: AnswerMemo) =>
+      createNewAnswerMemo(answerId, answerMemo),
+    onMutate: (answerMemo) => {
+      setAnswerMemo(answerMemo.content);
+      setIsMemoEditOpen(false);
+    },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        errorToast({
+          title: "메모 작성 실패",
+          description:
+            error.response?.data.message || "메모 작성에 실패했습니다.",
+        });
+      } else {
+        errorToast({
+          title: "메모 작성 실패",
+          description:
+            "서버 오류가 발생하여 메모 저장이 실패했습니다. 잠시 후 다시 시도해 주세요.",
+        });
+      }
+    },
+  });
+
+  const handleEditSubmitButtonClick = (data: AnswerMemo): void => {
+    createNewAnswerMemoMutate(data);
+    setIsMemoEditOpen(false);
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-2 w-full"
+      onSubmit={handleSubmit(handleEditSubmitButtonClick)}
+    >
+      <div className="flex justify-between">
+        <p>공개 범위</p>
+        <RadioGroup
+          onChange={(value) =>
+            setValue("visibility", value as "PUBLIC" | "PRIVATE")
+          }
+          value={watch("visibility")}
+        >
+          <Radio value="PUBLIC">공개</Radio>
+          <Radio value="PRIVATE">비공개</Radio>
+        </RadioGroup>
+      </div>
+      <p className="mt-4">메모 작성하기</p>
+      <Textarea
+        name="memo"
+        variant={"default"}
+        className="border border-border-secondary"
+        value={watch("content")}
+        onChange={(e) => setValue("content", e.target.value)}
+      />
+      {answerMemoFormErrors.content && (
+        <p className="text-red-500">{answerMemoFormErrors.content.message}</p>
+      )}
+      <div className="grid grid-cols-2 gap-2">
+        <Button
+          variant={"warning"}
+          type="button"
+          onClick={() => setIsMemoEditOpen(false)}
+        >
+          취소
+        </Button>
+        <Button variant={"success"} type="submit">
+          저장
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/client/src/domains/interviewReport/components/feedbackAccordion.tsx
+++ b/apps/client/src/domains/interviewReport/components/feedbackAccordion.tsx
@@ -10,10 +10,15 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@kokomen/ui/components/accordion";
-import { MessageSquare, Star, Award, NotebookPen } from "lucide-react";
-import { Button } from "@kokomen/ui/components/button";
+import { MessageSquare, Star, Award } from "lucide-react";
+import { JSX } from "react";
+import AnswerMemoComponent from "@/domains/interviewReport/components/answerMemo";
 
-export function FeedbackAccordion({ feedbacks }: { feedbacks: Feedback[] }) {
+export function FeedbackAccordion({
+  feedbacks,
+}: {
+  feedbacks: Feedback[];
+}): JSX.Element {
   return (
     <Accordion
       allowMultiple
@@ -21,92 +26,111 @@ export function FeedbackAccordion({ feedbacks }: { feedbacks: Feedback[] }) {
       className="w-full space-y-4"
     >
       {feedbacks.map((feedback, idx) => (
-        <AccordionItem
-          key={idx}
-          itemKey={`feedback-${feedback.question_id}-${idx}`}
-          className="border border-border rounded-xl overflow-hidden bg-bg-elevated shadow-sm hover:shadow-md transition-shadow duration-200"
-        >
-          <AccordionTrigger className="px-6 py-4 hover:bg-fill-secondary transition-colors duration-200">
-            <div className="flex items-center gap-3 w-full">
-              <div className="flex items-center justify-center w-8 h-8 bg-primary-bg rounded-full">
-                <span className="text-sm font-semibold text-primary">
-                  {idx + 1}
+        <FeedBackAccordionItem
+          key={feedback.question_id}
+          feedback={feedback}
+          idx={idx}
+        />
+      ))}
+    </Accordion>
+  );
+}
+
+function FeedBackAccordionItem({
+  feedback,
+  idx,
+}: {
+  feedback: Feedback;
+  idx: number;
+}): JSX.Element {
+  return (
+    <AccordionItem
+      key={feedback.question_id}
+      itemKey={`feedback-${feedback.question_id}`}
+      className="border border-border rounded-xl overflow-hidden bg-bg-elevated shadow-sm hover:shadow-md transition-shadow duration-200"
+    >
+      <AccordionTrigger className="px-6 py-4 hover:bg-fill-secondary transition-colors duration-200">
+        <div className="flex items-center gap-3 w-full">
+          <div className="flex items-center justify-center w-8 h-8 bg-primary-bg rounded-full">
+            <span className="text-sm font-semibold text-primary">
+              {idx + 1}
+            </span>
+          </div>
+          <span className="text-text-heading font-medium text-left flex-1">
+            {feedback.question}
+          </span>
+          <div
+            className={`flex items-center gap-2 px-3 py-1 rounded-full text-sm font-semibold ${getScoreColor(
+              feedback.answer_rank
+            )}`}
+          >
+            {getScoreIcon(feedback.answer_rank)}
+            {feedback.answer_rank}등급
+          </div>
+        </div>
+      </AccordionTrigger>
+      <AccordionContent className="px-6">
+        <div className="flex flex-col gap-6">
+          {/* 내 답변 섹션 */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <MessageSquare className="w-5 h-5 text-primary" />
+              <h4 className="text-lg font-semibold text-text-heading">
+                내 답변
+              </h4>
+            </div>
+            <div className="bg-primary-bg border border-primary-border rounded-xl p-4">
+              <p className="text-text-primary leading-relaxed">
+                {feedback.answer}
+              </p>
+            </div>
+          </div>
+
+          {/* 피드백 섹션 */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Award className="w-5 h-5 text-success" />
+              <h4 className="text-lg font-semibold text-text-heading">
+                피드백
+              </h4>
+            </div>
+            <div className="bg-success-bg border border-success-border rounded-xl p-4">
+              <p className="text-text-primary leading-relaxed">
+                {feedback.answer_feedback}
+              </p>
+            </div>
+          </div>
+
+          {/* 점수 요약 */}
+          <div className="flex items-center pt-4 border-t border-border gap-4">
+            <div className="flex gap-2">
+              <div className="flex items-center gap-2">
+                <Star className="w-5 h-5 text-warning" />
+                <span className="text-text-description font-medium">
+                  이 질문의 평가
                 </span>
               </div>
-              <span className="text-text-heading font-medium text-left flex-1">
-                {feedback.question}
-              </span>
               <div
-                className={`flex items-center gap-2 px-3 py-1 rounded-full text-sm font-semibold ${getScoreColor(
+                className={`flex items-center gap-2 px-4 py-2 rounded-full font-semibold ${getScoreColor(
                   feedback.answer_rank
                 )}`}
               >
                 {getScoreIcon(feedback.answer_rank)}
-                {feedback.answer_rank}등급
+                <span className="text-lg">
+                  {feedback.answer_rank}등급 (
+                  {getScoreLabel(feedback.answer_rank)})
+                </span>
               </div>
             </div>
-          </AccordionTrigger>
-          <AccordionContent className="px-6">
-            <div className="space-y-6">
-              {/* 내 답변 섹션 */}
-              <div className="space-y-3">
-                <div className="flex items-center gap-2">
-                  <MessageSquare className="w-5 h-5 text-primary" />
-                  <h4 className="text-lg font-semibold text-text-heading">
-                    내 답변
-                  </h4>
-                </div>
-                <div className="bg-primary-bg border border-primary-border rounded-xl p-4">
-                  <p className="text-text-primary leading-relaxed">
-                    {feedback.answer}
-                  </p>
-                </div>
-              </div>
-
-              {/* 피드백 섹션 */}
-              <div className="space-y-3">
-                <div className="flex items-center gap-2">
-                  <Award className="w-5 h-5 text-success" />
-                  <h4 className="text-lg font-semibold text-text-heading">
-                    피드백
-                  </h4>
-                </div>
-                <div className="bg-success-bg border border-success-border rounded-xl p-4">
-                  <p className="text-text-primary leading-relaxed">
-                    {feedback.answer_feedback}
-                  </p>
-                </div>
-              </div>
-
-              {/* 점수 요약 */}
-              <div className="flex items-center pt-4 border-t border-border gap-4">
-                <div className="flex gap-2">
-                  <div className="flex items-center gap-2">
-                    <Star className="w-5 h-5 text-warning" />
-                    <span className="text-text-description font-medium">
-                      이 질문의 평가
-                    </span>
-                  </div>
-                  <div
-                    className={`flex items-center gap-2 px-4 py-2 rounded-full font-semibold ${getScoreColor(
-                      feedback.answer_rank
-                    )}`}
-                  >
-                    {getScoreIcon(feedback.answer_rank)}
-                    <span className="text-lg">
-                      {feedback.answer_rank}등급 (
-                      {getScoreLabel(feedback.answer_rank)})
-                    </span>
-                  </div>
-                </div>
-                <Button variant={"glass"}>
-                  <NotebookPen /> 메모 작성하기
-                </Button>
-              </div>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-      ))}
-    </Accordion>
+          </div>
+          <AnswerMemoComponent
+            answerId={feedback.answer_id}
+            answerMemoProp={feedback.submitted_answer_memo_content}
+            tempMemo={feedback.temp_answer_memo_content}
+            visibility={feedback.answer_memo_visibility}
+          />
+        </div>
+      </AccordionContent>
+    </AccordionItem>
   );
 }

--- a/apps/client/src/domains/interviewReport/components/feedbackAccordion.tsx
+++ b/apps/client/src/domains/interviewReport/components/feedbackAccordion.tsx
@@ -1,68 +1,19 @@
 import { Feedback } from "@/domains/interviewReport/types";
 import {
+  getScoreColor,
+  getScoreIcon,
+  getScoreLabel,
+} from "@/utils/rankDisplay";
+import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from "@kokomen/ui/components/accordion";
-import {
-  MessageSquare,
-  Star,
-  Award,
-  CheckCircle,
-  AlertCircle,
-} from "lucide-react";
+import { MessageSquare, Star, Award, NotebookPen } from "lucide-react";
+import { Button } from "@kokomen/ui/components/button";
 
 export function FeedbackAccordion({ feedbacks }: { feedbacks: Feedback[] }) {
-  const getScoreColor = (rank: string) => {
-    switch (rank.toUpperCase()) {
-      case "A":
-        return "text-success";
-      case "B":
-        return "text-primary";
-      case "C":
-        return "text-warning";
-      case "D":
-      case "F":
-        return "text-error";
-      default:
-        return "text-text-description";
-    }
-  };
-
-  const getScoreIcon = (rank: string) => {
-    switch (rank.toUpperCase()) {
-      case "A":
-        return <Award className="w-5 h-5" />;
-      case "B":
-        return <Star className="w-5 h-5" />;
-      case "C":
-        return <CheckCircle className="w-5 h-5" />;
-      case "D":
-      case "F":
-        return <AlertCircle className="w-5 h-5" />;
-      default:
-        return <Star className="w-5 h-5" />;
-    }
-  };
-
-  const getScoreLabel = (rank: string) => {
-    switch (rank.toUpperCase()) {
-      case "A":
-        return "우수";
-      case "B":
-        return "양호";
-      case "C":
-        return "보통";
-      case "D":
-        return "미흡";
-      case "F":
-        return "불량";
-      default:
-        return rank;
-    }
-  };
-
   return (
     <Accordion
       allowMultiple
@@ -128,24 +79,29 @@ export function FeedbackAccordion({ feedbacks }: { feedbacks: Feedback[] }) {
               </div>
 
               {/* 점수 요약 */}
-              <div className="flex items-center justify-between pt-4 border-t border-border">
-                <div className="flex items-center gap-2">
-                  <Star className="w-5 h-5 text-warning" />
-                  <span className="text-text-description font-medium">
-                    이 질문의 평가
-                  </span>
+              <div className="flex items-center pt-4 border-t border-border gap-4">
+                <div className="flex gap-2">
+                  <div className="flex items-center gap-2">
+                    <Star className="w-5 h-5 text-warning" />
+                    <span className="text-text-description font-medium">
+                      이 질문의 평가
+                    </span>
+                  </div>
+                  <div
+                    className={`flex items-center gap-2 px-4 py-2 rounded-full font-semibold ${getScoreColor(
+                      feedback.answer_rank
+                    )}`}
+                  >
+                    {getScoreIcon(feedback.answer_rank)}
+                    <span className="text-lg">
+                      {feedback.answer_rank}등급 (
+                      {getScoreLabel(feedback.answer_rank)})
+                    </span>
+                  </div>
                 </div>
-                <div
-                  className={`flex items-center gap-2 px-4 py-2 rounded-full font-semibold ${getScoreColor(
-                    feedback.answer_rank
-                  )}`}
-                >
-                  {getScoreIcon(feedback.answer_rank)}
-                  <span className="text-lg">
-                    {feedback.answer_rank}등급 (
-                    {getScoreLabel(feedback.answer_rank)})
-                  </span>
-                </div>
+                <Button variant={"glass"}>
+                  <NotebookPen /> 메모 작성하기
+                </Button>
               </div>
             </div>
           </AccordionContent>

--- a/apps/client/src/domains/interviewReport/types/index.ts
+++ b/apps/client/src/domains/interviewReport/types/index.ts
@@ -5,6 +5,9 @@ interface Feedback {
   answer: string;
   answer_rank: string;
   answer_feedback: string;
+  temp_answer_memo_content: string;
+  submitted_answer_memo_content: string;
+  answer_memo_visibility: "PUBLIC" | "PRIVATE" | "FRIENDS";
 }
 interface InterviewReport {
   feedbacks: Feedback[];

--- a/apps/client/src/domains/interviewReport/types/memo.ts
+++ b/apps/client/src/domains/interviewReport/types/memo.ts
@@ -1,0 +1,6 @@
+type AnswerMemo = {
+  visibility: "PUBLIC" | "PRIVATE" | "FRIENDS";
+  content: string;
+};
+
+export type { AnswerMemo };

--- a/apps/client/src/domains/members/components/memberQuestionFeedback.tsx
+++ b/apps/client/src/domains/members/components/memberQuestionFeedback.tsx
@@ -129,7 +129,7 @@ export default function MemberQuestionFeedback({
           </div>
         </div>
 
-        {/* 피드백 섹션 */}
+        {/* AI 피드백 섹션 */}
         <div className="space-y-3">
           <div className="flex items-center space-x-2">
             <div className="w-3 h-3 bg-gradient-to-r from-cyan-4 to-cyan-5 rounded-full"></div>
@@ -141,6 +141,23 @@ export default function MemberQuestionFeedback({
             </p>
           </div>
         </div>
+
+        {/* 사용자 메모 섹션 */}
+        {questionAndFeedback.submittedAnswerMemoContent && (
+          <div className="space-y-3">
+            <div className="flex items-center space-x-2">
+              <div className="w-3 h-3 bg-gradient-to-r from-green-4 to-green-5 rounded-full"></div>
+              <h4 className="text-sm font-semibold text-gray-700">
+                사용자 메모
+              </h4>
+            </div>
+            <div className="bg-gradient-to-r from-green-1 to-green-2 rounded-xl p-4 border border-green-3">
+              <p className="text-gray-800 leading-relaxed whitespace-pre-wrap">
+                {questionAndFeedback.submittedAnswerMemoContent}
+              </p>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/client/src/domains/members/components/memberTotalFeedback.tsx
+++ b/apps/client/src/domains/members/components/memberTotalFeedback.tsx
@@ -1,6 +1,6 @@
 import { toggleMemberInterviewLike } from "@/domains/members/api";
 import { useMutation } from "@tanstack/react-query";
-import { CheckCircle, Heart, MessageCircle, Trophy } from "lucide-react";
+import { CheckCircle, Eye, Heart, MessageCircle, Trophy } from "lucide-react";
 import { JSX, useState } from "react";
 import { useToast } from "@kokomen/ui/hooks/useToast";
 import { isAxiosError } from "axios";
@@ -60,7 +60,7 @@ export default function MemberTotalFeedback({
 
   return (
     <div className="p-8">
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
         {/* 총점 */}
         <div className="text-center">
           <div className="w-16 h-16 bg-gradient-primary rounded-full flex items-center justify-center mx-auto mb-4">
@@ -90,6 +90,16 @@ export default function MemberTotalFeedback({
           </div>
           <p className="text-2xl font-bold text-gray-900">{totalLikedCount}</p>
           <p className="text-sm text-gray-600">좋아요</p>
+        </div>
+
+        <div className="text-center">
+          <div className="w-16 h-16 bg-gradient-to-br from-purple-3 to-purple-6 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Eye className="w-8 h-8 text-white" />
+          </div>
+          <p className="text-2xl font-bold text-gray-900">
+            {result.interviewViewCount}
+          </p>
+          <p className="text-sm text-gray-600">조회수</p>
         </div>
       </div>
 

--- a/apps/client/src/domains/members/types/index.ts
+++ b/apps/client/src/domains/members/types/index.ts
@@ -34,12 +34,14 @@ type Feedback = {
   answer_feedback: string;
   answer_like_count: number;
   answer_already_liked: boolean;
+  submitted_answer_memo_content: string;
 };
 
 type MemberInterviewResult = {
   feedbacks: Feedback[];
   total_feedback: string;
   total_score: number;
+  interview_view_count: number;
   interview_like_count: number;
   interview_already_liked: boolean;
   interviewee_rank: number;

--- a/apps/client/src/hooks/useModal.ts
+++ b/apps/client/src/hooks/useModal.ts
@@ -21,3 +21,25 @@ export const useSidebar = (
     toggleSidebar,
   };
 };
+
+export const useModal = (
+  initialOpen = false
+): {
+  isOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+  toggleModal: () => void;
+} => {
+  const [isOpen, setIsOpen] = useState(initialOpen);
+
+  const openModal = (): void => setIsOpen(true);
+  const closeModal = (): void => setIsOpen(false);
+  const toggleModal = (): void => setIsOpen(!isOpen);
+
+  return {
+    isOpen,
+    openModal,
+    closeModal,
+    toggleModal,
+  };
+};

--- a/apps/client/src/pages/interviews/[interviewId]/result.tsx
+++ b/apps/client/src/pages/interviews/[interviewId]/result.tsx
@@ -178,16 +178,21 @@ export const getServerSideProps: GetServerSideProps<
       notFound: true,
     };
   }
-  return withCheckInServer(async () => {
-    const [report, userInfo] = await Promise.all([
-      getInterviewReport(context.req.cookies, interviewId as string),
-      getUserInfo(context),
-    ]);
-    return {
-      data: {
-        report: report.data,
-        userInfo: userInfo.data,
-      },
-    };
-  });
+  return withCheckInServer(
+    async () => {
+      const [report, userInfo] = await Promise.all([
+        getInterviewReport(context.req.cookies, interviewId as string),
+        getUserInfo(context),
+      ]);
+      return {
+        data: {
+          report: report.data,
+          userInfo: userInfo.data,
+        },
+      };
+    },
+    {
+      redirectPathWhenUnauthorized: "/interviews",
+    }
+  );
 };

--- a/apps/client/src/pages/interviews/[interviewId]/result.tsx
+++ b/apps/client/src/pages/interviews/[interviewId]/result.tsx
@@ -25,7 +25,7 @@ import { getUserInfo } from "@/domains/auth/api";
 import { User } from "@/domains/auth/types";
 import { SEO } from "@/shared/seo";
 
-export default function Result({
+export default function MyInterviewResultPage({
   report,
   userInfo,
 }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {

--- a/apps/client/src/pages/members/[memberId].tsx
+++ b/apps/client/src/pages/members/[memberId].tsx
@@ -13,8 +13,8 @@ import { getMemberInterviews } from "@/domains/members/api";
 import { MemberInterview } from "@/domains/members/types";
 import { CamelCasedProperties } from "@/utils/convertConvention";
 import { TrendingUp } from "lucide-react";
-import { getRankDisplay, getPercentileDisplay } from "@/utils/rankDisplay";
 import { SEO } from "@/shared/seo";
+import { getRankDisplay, getPercentileDisplay } from "@/utils/rankDisplay";
 
 export default function MemberInterviewPage({
   memberId,

--- a/apps/client/src/utils/auth.ts
+++ b/apps/client/src/utils/auth.ts
@@ -14,6 +14,7 @@ export async function withCheckInServer<T>(
     ) => GetServerSidePropsResult<T>;
     // 에러 로깅 비활성화
     context?: GetServerSidePropsContext;
+    redirectPathWhenUnauthorized?: string;
   }
 ): Promise<GetServerSidePropsResult<T>> {
   const { onError, context } = options || {};
@@ -53,12 +54,21 @@ export async function withCheckInServer<T>(
       switch (status) {
         case 401:
         case 403:
-          return {
-            redirect: {
-              destination: `${LOGIN_PATH}?redirectTo=${context?.resolvedUrl}`,
-              permanent: false,
-            },
-          };
+          if (options?.redirectPathWhenUnauthorized) {
+            return {
+              redirect: {
+                destination: `${LOGIN_PATH}?redirectTo=${context?.resolvedUrl}`,
+                permanent: false,
+              },
+            };
+          } else {
+            return {
+              redirect: {
+                destination: options?.redirectPathWhenUnauthorized as string,
+                permanent: false,
+              },
+            };
+          }
         case 404:
           return {
             notFound: true,

--- a/apps/client/src/utils/rankDisplay.tsx
+++ b/apps/client/src/utils/rankDisplay.tsx
@@ -1,4 +1,13 @@
-import { Award, Crown, Medal, Trophy } from "lucide-react";
+import {
+  AlertCircle,
+  Award,
+  CheckCircle,
+  Crown,
+  Medal,
+  Star,
+  Trophy,
+} from "lucide-react";
+import React from "react";
 
 // 랭킹에 따른 아이콘과 색상 결정하는 함수
 const getRankDisplay = (rank: number) => {
@@ -39,4 +48,59 @@ const getPercentileDisplay = (percentile: number) => {
   }
 };
 
-export { getRankDisplay, getPercentileDisplay };
+const getScoreColor = (rank: string): string => {
+  switch (rank.toUpperCase()) {
+    case "A":
+      return "text-success";
+    case "B":
+      return "text-primary";
+    case "C":
+      return "text-warning";
+    case "D":
+    case "F":
+      return "text-error";
+    default:
+      return "text-text-description";
+  }
+};
+
+const getScoreIcon = (rank: string): React.ReactNode => {
+  switch (rank.toUpperCase()) {
+    case "A":
+      return <Award className="w-5 h-5" />;
+    case "B":
+      return <Star className="w-5 h-5" />;
+    case "C":
+      return <CheckCircle className="w-5 h-5" />;
+    case "D":
+    case "F":
+      return <AlertCircle className="w-5 h-5" />;
+    default:
+      return <Star className="w-5 h-5" />;
+  }
+};
+
+const getScoreLabel = (rank: string): string => {
+  switch (rank.toUpperCase()) {
+    case "A":
+      return "우수";
+    case "B":
+      return "양호";
+    case "C":
+      return "보통";
+    case "D":
+      return "미흡";
+    case "F":
+      return "불량";
+    default:
+      return rank;
+  }
+};
+
+export {
+  getRankDisplay,
+  getPercentileDisplay,
+  getScoreColor,
+  getScoreIcon,
+  getScoreLabel,
+};

--- a/packages/ui/src/components/accordion/index.tsx
+++ b/packages/ui/src/components/accordion/index.tsx
@@ -239,13 +239,37 @@ export function AccordionContent({
   const panelRef = useRef<HTMLDivElement>(null);
   const [panelHeight, setPanelHeight] = useState<string>("0px");
 
-  useEffect(() => {
+  const handleResize = () => {
     if (isOpen && panelRef.current) {
       setPanelHeight(`${panelRef.current.scrollHeight}px`);
     } else {
       setPanelHeight("0px");
     }
+  };
+
+  useEffect(() => {
+    handleResize();
   }, [isOpen, children]);
+
+  useEffect(() => {
+    let observer: MutationObserver | null = null;
+
+    if (panelRef.current) {
+      observer = new MutationObserver(handleResize);
+      observer.observe(panelRef.current, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+      });
+    }
+
+    return () => {
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+  }, [isOpen]);
 
   return (
     <div

--- a/packages/ui/src/components/modal/index.tsx
+++ b/packages/ui/src/components/modal/index.tsx
@@ -5,7 +5,7 @@ import { Button } from "#components/button/index.tsx";
 
 type ModalVariants = VariantProps<typeof modalVariants>;
 const modalVariants = cva(
-  "relative bg-white rounded-lg shadow-xl w-full mx-4 transform transition-all",
+  "relative bg-white rounded-lg shadow-xl w-full mx-4 transform transition-all animate-modal-pop-in",
   {
     variants: {
       size: {

--- a/packages/ui/src/components/radio/index.tsx
+++ b/packages/ui/src/components/radio/index.tsx
@@ -1,0 +1,314 @@
+import { cva, VariantProps } from "class-variance-authority";
+import React, { createContext, useContext, useId } from "react";
+import { cn } from "../../utils/index.ts";
+
+// Radio 컨텍스트 타입
+interface RadioContextValue {
+  value?: string;
+  onChange?: (value: string) => void;
+  name: string;
+  disabled?: boolean;
+  size?: "small" | "medium" | "large";
+  variant?: "primary" | "success" | "warning" | "error";
+}
+
+// Radio 컨텍스트 생성
+const RadioContext = createContext<RadioContextValue | undefined>(undefined);
+
+// Radio 스타일 variants 정의
+const radioVariants = cva(
+  `
+  relative inline-flex items-center justify-center rounded-full border-2 
+  transition-all duration-200 ease-in-out cursor-pointer
+  focus:outline-none focus:ring-2 focus:ring-offset-2
+  disabled:cursor-not-allowed disabled:opacity-50
+  `,
+  {
+    variants: {
+      variant: {
+        primary: `
+          border-border text-primary
+          hover:border-primary-border-hover
+          focus:border-primary-border focus:ring-primary-bg
+          checked:border-primary checked:bg-primary
+          checked:hover:border-primary-hover checked:hover:bg-primary-hover
+          checked:active:border-primary-active checked:active:bg-primary-active
+        `,
+        success: `
+          border-border text-success
+          hover:border-success-border-hover
+          focus:border-success-border focus:ring-success-bg
+          checked:border-success checked:bg-success
+          checked:hover:border-success-hover checked:hover:bg-success-hover
+          checked:active:border-success-active checked:active:bg-success-active
+        `,
+        warning: `
+          border-border text-warning
+          hover:border-warning-border-hover
+          focus:border-warning-border focus:ring-warning-bg
+          checked:border-warning checked:bg-warning
+          checked:hover:border-warning-hover checked:hover:bg-warning-hover
+          checked:active:border-warning-active checked:active:bg-warning-active
+        `,
+        error: `
+          border-border text-error
+          hover:border-error-border-hover
+          focus:border-error-border focus:ring-error-bg
+          checked:border-error checked:bg-error
+          checked:hover:border-error-hover checked:hover:bg-error-hover
+          checked:active:border-error-active checked:active:bg-error-active
+        `,
+      },
+      size: {
+        small: "w-4 h-4",
+        medium: "w-5 h-5",
+        large: "w-6 h-6",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "medium",
+    },
+  }
+);
+
+// Radio 내부 점 스타일
+const radioInnerVariants = cva(
+  `
+  absolute rounded-full bg-text-light-solid
+  transition-all duration-200 ease-in-out
+  `,
+  {
+    variants: {
+      size: {
+        small: "w-1.5 h-1.5",
+        medium: "w-2 h-2",
+        large: "w-2.5 h-2.5",
+      },
+    },
+    defaultVariants: {
+      size: "medium",
+    },
+  }
+);
+
+// Label 스타일
+const labelVariants = cva(
+  `
+  ml-2 cursor-pointer select-none
+  transition-colors duration-200 ease-in-out
+  disabled:cursor-not-allowed disabled:opacity-50
+  `,
+  {
+    variants: {
+      size: {
+        small: "text-sm",
+        medium: "text-base",
+        large: "text-lg",
+      },
+    },
+    defaultVariants: {
+      size: "medium",
+    },
+  }
+);
+
+// RadioGroup Props
+export interface RadioGroupProps {
+  children: React.ReactNode;
+  value?: string;
+  onChange?: (value: string) => void;
+  name?: string;
+  disabled?: boolean;
+  size?: "small" | "medium" | "large";
+  variant?: "primary" | "success" | "warning" | "error";
+  className?: string;
+  "aria-label"?: string;
+}
+
+// Radio Props
+export interface RadioProps extends VariantProps<typeof radioVariants> {
+  value: string;
+  children?: React.ReactNode;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  "aria-label"?: string;
+  "aria-describedby"?: string;
+}
+
+// RadioGroup 컴포넌트
+export const RadioGroup = ({
+  children,
+  value,
+  onChange,
+  name: propName,
+  disabled = false,
+  size = "medium",
+  variant = "primary",
+  className,
+  "aria-label": ariaLabel,
+}: RadioGroupProps) => {
+  const generatedName = useId();
+  const name = propName || generatedName;
+
+  const contextValue: RadioContextValue = {
+    value,
+    onChange,
+    name,
+    disabled,
+    size,
+    variant,
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+      e.preventDefault();
+      // 다음 라디오 버튼으로 포커스 이동
+      const radioButtons = Array.from(
+        document.querySelectorAll(`input[name="${name}"]`)
+      ) as HTMLInputElement[];
+      const currentIndex = radioButtons.findIndex(
+        (radio) => radio === document.activeElement
+      );
+      const nextIndex = (currentIndex + 1) % radioButtons.length;
+      radioButtons[nextIndex]?.focus();
+      onChange?.(radioButtons[nextIndex].value);
+    } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      // 이전 라디오 버튼으로 포커스 이동
+      const radioButtons = Array.from(
+        document.querySelectorAll(`input[name="${name}"]`)
+      ) as HTMLInputElement[];
+      const currentIndex = radioButtons.findIndex(
+        (radio) => radio === document.activeElement
+      );
+      const prevIndex =
+        currentIndex === 0 ? radioButtons.length - 1 : currentIndex - 1;
+      radioButtons[prevIndex]?.focus();
+      onChange?.(radioButtons[prevIndex].value);
+    }
+  };
+
+  return (
+    <RadioContext.Provider value={contextValue}>
+      <div
+        className={cn("flex gap-4 items-center", className)}
+        role="radiogroup"
+        aria-label={ariaLabel}
+        onKeyDown={handleKeyDown}
+      >
+        {children}
+      </div>
+    </RadioContext.Provider>
+  );
+};
+
+// Radio 컴포넌트
+export const Radio = ({
+  value,
+  children,
+  disabled: propDisabled = false,
+  className,
+  id: propId,
+  "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedBy,
+}: RadioProps) => {
+  const context = useContext(RadioContext);
+  const generatedId = useId();
+  const id = propId || generatedId;
+
+  if (!context) {
+    throw new Error("Radio must be used within a RadioGroup");
+  }
+
+  const {
+    value: groupValue,
+    onChange,
+    name,
+    disabled: groupDisabled,
+    size,
+    variant,
+  } = context;
+
+  const isDisabled = groupDisabled || propDisabled;
+  const isChecked = groupValue === value;
+
+  const handleChange = () => {
+    if (!isDisabled && onChange) {
+      onChange(value);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      handleChange();
+    }
+  };
+
+  return (
+    <label
+      htmlFor={id}
+      className={cn(
+        "flex items-center",
+        labelVariants({ size }),
+        isDisabled && "cursor-not-allowed opacity-50",
+        className
+      )}
+    >
+      <div className="relative flex items-center justify-center gap-2">
+        <input
+          type="radio"
+          id={id}
+          name={name}
+          value={value}
+          checked={isChecked}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          disabled={isDisabled}
+          className="sr-only"
+          aria-label={ariaLabel}
+          aria-describedby={ariaDescribedBy}
+        />
+        <div
+          className={cn(
+            radioVariants({ variant, size }),
+            isChecked && "border-opacity-100",
+            isDisabled && "opacity-50"
+          )}
+          style={{
+            backgroundColor: isChecked
+              ? `var(--color-${variant})`
+              : "transparent",
+            borderColor: isChecked
+              ? `var(--color-${variant})`
+              : `var(--color-border)`,
+          }}
+        >
+          {isChecked && (
+            <div
+              className={cn(radioInnerVariants({ size }))}
+              style={{
+                backgroundColor: "var(--color-text-light-solid)",
+              }}
+            />
+          )}
+        </div>
+      </div>
+      {children && (
+        <span
+          className={cn(
+            "text-text-primary ml-2",
+            isDisabled && "text-text-disabled"
+          )}
+        >
+          {children}
+        </span>
+      )}
+    </label>
+  );
+};
+
+// 기본 export
+export { RadioGroup as default };

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -201,6 +201,17 @@
   --color-success-text: var(--color-green-9);
   --color-success-text-active: var(--color-green-10);
 
+  --color-warning-bg: var(--color-volcano-1);
+  --color-warning-bg-hover: var(--color-volcano-2);
+  --color-warning-border: var(--color-volcano-3);
+  --color-warning-border-hover: var(--color-volcano-4);
+  --color-warning-hover: var(--color-volcano-4);
+  --color-warning: var(--color-volcano-6);
+  --color-warning-active: var(--color-volcano-7);
+  --color-warning-text-hover: var(--color-volcano-8);
+  --color-warning-text: var(--color-volcano-9);
+  --color-warning-text-active: var(--color-volcano-10);
+
   /* Error Color Tokens - 기존 red 팔레트 활용 */
   --color-error-bg: var(--color-red-1); /* #fff1f0 */
   --color-error-bg-hover: var(--color-red-2); /* #ffccc7 */
@@ -562,6 +573,18 @@
   100% {
     transform: translateX(0) scale(1);
     opacity: 1;
+  }
+}
+
+@theme {
+  --animate-modal-pop-in: modal-pop-in 0.3s ease-out forwards;
+  @keyframes modal-pop-in {
+    from {
+      transform: scale(0.9);
+    }
+    to {
+      transform: scale(1);
+    }
   }
 }
 


### PR DESCRIPTION
## 📌 개요

## ✅ 작업 내용

- [x] 인터뷰에 대해서 결과 페이지에서 메모 작성 기능 추가
- [x] 작성된 메모는 작성했을 때 설정한 공개범위에 따라 볼 수 있도록 설정
- [x] form내에서 쓰일 radio 컴포넌트 추가
- [x] 모달 관련 애니메이션 추가
- [x] 각 대시보드에서 메모 인터페이스 추가
- [x] 메모 API 연결 후 낙관적업데이트 적용

## 🧪 테스트

- [x] 직접 테스트 완료
- [x] 테스트 코드 추가됨 (해당 시)

## 📝 참고 사항

- 없음

## 📎 관련 이슈

Closes #59 
