### PR TITLE
[Feat/#90, #88] - 웹뷰 대시보드 기능 및 로그인 유지 추가

### DIFF
--- a/apps/kokomen-webview/package.json
+++ b/apps/kokomen-webview/package.json
@@ -19,7 +19,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.59.0",
-    "zod": "^3.25.74"
+    "zod": "^3.25.74",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/apps/kokomen-webview/src/domains/auth/api/index.ts
+++ b/apps/kokomen-webview/src/domains/auth/api/index.ts
@@ -1,4 +1,4 @@
-import { User } from "@kokomen/types/auth";
+import { User, UserInfo } from "@kokomen/types/auth";
 import axios, { AxiosInstance, AxiosPromise } from "axios";
 
 const authServerInstance: AxiosInstance = axios.create({
@@ -6,23 +6,17 @@ const authServerInstance: AxiosInstance = axios.create({
   withCredentials: true
 });
 
-interface KakaoLoginResponse {
-  id: number;
-  nickname: string;
-  profile_completed: boolean;
-}
-
 const postAuthorizationCode = async (
   code: string,
   redirectUri: string
-): AxiosPromise<KakaoLoginResponse> => {
+): AxiosPromise<User> => {
   return authServerInstance.post(`/auth/kakao-login`, {
     code,
     redirect_uri: redirectUri
   });
 };
 
-const getUserInfo = async (): AxiosPromise<User> => {
+const getUserInfo = async (): AxiosPromise<UserInfo> => {
   return authServerInstance.get(`/members/me/profile`);
 };
 

--- a/apps/kokomen-webview/src/domains/dashboard/components/interviewHistory.tsx
+++ b/apps/kokomen-webview/src/domains/dashboard/components/interviewHistory.tsx
@@ -1,6 +1,6 @@
 import { getInterviewHistory } from "@/domains/dashboard/api";
-import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
-import { interviewHistoryKeys } from "@/utils/querykeys";
+import { useIntersectionObserver } from "@kokomen/utils/react/useIntersectionObserver";
+import { interviewHistoryKeys } from "@kokomen/utils/general/querykeys";
 import Select from "@kokomen/ui/components/select";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import {
@@ -134,7 +134,7 @@ export default function InterviewHistory() {
           </h3>
           <p className="text-gray-600 mb-6">첫 번째 면접을 시작해보세요!</p>
           <Link
-            href="/interviews"
+            to="/interviews"
             className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700"
           >
             면접 시작하기
@@ -162,80 +162,92 @@ export default function InterviewHistory() {
                     {interview.root_question}
                   </p>
 
-                  <div className="flex items-center gap-6 text-sm text-gray-500">
-                    <div className="flex items-center gap-1">
-                      <Calendar className="w-4 h-4" />
-                      {formatDate(interview.created_at)}
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <Clock className="w-4 h-4" />
-                      {interview.cur_answer_count}/
-                      {interview.max_question_count}문제
-                    </div>
-                    {interview.interview_state === "FINISHED" && (
-                      <div
-                        className={`flex items-center gap-1 ${
-                          interview.score > 0
-                            ? "text-green-6"
-                            : "text-volcano-6"
-                        }`}
-                      >
-                        <TrendingUp className="w-4 h-4" />
-                        {interview.score}점
+                  <div className="flex flex-col gap-3 text-sm text-gray-500">
+                    <div className="flex gap-6">
+                      <div className="flex items-center gap-1">
+                        <Calendar className="w-4 h-4" />
+                        {formatDate(interview.created_at)}
                       </div>
-                    )}
-                    {interview.interview_state === "FINISHED" && (
-                      <>
-                        <div className="flex items-center gap-1">
-                          <Eye className="w-4 h-4" />
-                          {interview.interview_view_count}
-                        </div>
-                        <div
-                          className={`flex items-center gap-1 ${
-                            interview.interview_already_liked
-                              ? "text-volcano-6"
-                              : "text-gray-400"
-                          }`}
-                        >
-                          <Heart className="w-4 h-4" />
-                          {interview.interview_like_count}
-                        </div>
-                        <div
-                          className={`flex items-center gap-1 ${
-                            interview.submitted_answer_memo_count > 0
-                              ? "text-gold-6"
-                              : "text-gray-400"
-                          }`}
-                        >
-                          <NotebookPen className="w-4 h-4" />
-                          {interview.submitted_answer_memo_count}
-                        </div>
-                      </>
-                    )}
+                      <div className="flex items-center gap-1">
+                        <Clock className="w-4 h-4" />
+                        {interview.cur_answer_count}/
+                        {interview.max_question_count}문제
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-4">
+                      {interview.interview_state === "FINISHED" && (
+                        <>
+                          <div
+                            className={`flex items-center gap-1 ${
+                              interview.score > 0
+                                ? "text-green-6"
+                                : "text-volcano-6"
+                            }`}
+                          >
+                            <TrendingUp className="w-4 h-4" />
+                            {interview.score}점
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Eye className="w-4 h-4" />
+                            {interview.interview_view_count}
+                          </div>
+                          <div
+                            className={`flex items-center gap-1 ${
+                              interview.interview_already_liked
+                                ? "text-volcano-6"
+                                : "text-gray-400"
+                            }`}
+                          >
+                            <Heart className="w-4 h-4" />
+                            {interview.interview_like_count}
+                          </div>
+                          <div
+                            className={`flex items-center gap-1 ${
+                              interview.submitted_answer_memo_count > 0
+                                ? "text-gold-6"
+                                : "text-gray-400"
+                            }`}
+                          >
+                            <NotebookPen className="w-4 h-4" />
+                            {interview.submitted_answer_memo_count}
+                          </div>
+                        </>
+                      )}
+                    </div>
                   </div>
                 </div>
 
                 <div className="md:ml-4 md:w-auto w-full flex flex-col gap-2">
-                  <Link
-                    href={
-                      interview.interview_state === "FINISHED"
-                        ? `/interviews/${interview.interview_id}/result`
-                        : `/interviews/${interview.interview_id}`
-                    }
-                    className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-blue-600 bg-blue-50 hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
-                  >
-                    {interview.interview_state === "FINISHED"
-                      ? "보고서 보기"
-                      : "이어하기"}
-                  </Link>
-                  {interview.interview_state === "FINISHED" && (
+                  {interview.interview_state === "FINISHED" ? (
                     <Link
-                      href={`/members/interviews/${interview.interview_id}`}
+                      to={`/interviews/$interviewId/result`}
+                      params={{
+                        interviewId: interview.interview_id.toString()
+                      }}
+                      className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-blue-600 bg-blue-50 hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
+                    >
+                      보고서 보기
+                    </Link>
+                  ) : (
+                    <Link
+                      to={`/interviews/$interviewId`}
+                      params={{
+                        interviewId: interview.interview_id.toString()
+                      }}
+                      className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-blue-600 bg-blue-50 hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
+                    >
+                      이어하기
+                    </Link>
+                  )}
+                  {/* TODO: 면접이 완료된 경우에만 공개된 결과 보기 버튼을 보여주기 */}
+                  {/* {interview.interview_state === "FINISHED" && (
+                    <Link
+                      to={`/members/interviews/`}
                       className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-text-light-solid bg-gradient-primary hover:bg-blue-100 transition-colors md:w-auto w-full justify-center"
                     >
                       공개된 결과 보기
                     </Link>
-                  )}
+                  )} */}
                 </div>
               </div>
             </div>

--- a/apps/kokomen-webview/src/main.tsx
+++ b/apps/kokomen-webview/src/main.tsx
@@ -2,7 +2,15 @@ import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery
+} from "@tanstack/react-query";
+import { meKeys } from "@kokomen/utils/general/querykeys";
+import { getUserInfo } from "@/domains/auth/api";
+import { useAuthStore } from "@/store";
+import { LoadingFullScreen } from "@kokomen/ui/components/spinner";
 
 declare module "@tanstack/react-router" {
   interface Register {
@@ -22,13 +30,38 @@ const router = createRouter({
   context: undefined as unknown as RouterContext
 });
 
+function AuthRouter() {
+  const {
+    isError,
+    isPending,
+    data: userData
+  } = useQuery({
+    queryKey: meKeys.me(),
+    queryFn: getUserInfo,
+    staleTime: 1000 * 60 * 60 * 24,
+    gcTime: 1000 * 60 * 60 * 24,
+    retry: 1
+  });
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+  if (isPending) {
+    return <LoadingFullScreen className="w-screen h-screen" />;
+  }
+  if (isError) {
+    clearAuth();
+  }
+  if (userData) {
+    useAuthStore.getState().setAuth(userData.data);
+  }
+  return <RouterProvider router={router} context={{ queryClient }} />;
+}
+
 const rootElement = document.getElementById("root")!;
 if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} context={{ queryClient }} />
+        <AuthRouter />
       </QueryClientProvider>
     </StrictMode>
   );

--- a/apps/kokomen-webview/src/routes/dashboard/index.tsx
+++ b/apps/kokomen-webview/src/routes/dashboard/index.tsx
@@ -1,9 +1,102 @@
-import { createFileRoute } from "@tanstack/react-router";
+import InterviewHistory from "@/domains/dashboard/components/interviewHistory";
+import { useAuthStore, useUser } from "@/store";
+import {
+  createFileRoute,
+  redirect,
+  useLoaderData
+} from "@tanstack/react-router";
+import { Percentile, Rank } from "@kokomen/ui/components/rank";
+import { Coins, Star, User } from "lucide-react";
+import { getUserInfo } from "@/domains/auth/api";
+import { LoadingFullScreen } from "@kokomen/ui/components/spinner";
 
 export const Route = createFileRoute("/dashboard/")({
   component: RouteComponent,
+  beforeLoad: async () => {
+    console.log(useAuthStore.getState().isAuthenticated);
+    if (!useAuthStore.getState().isAuthenticated) {
+      throw redirect({
+        to: "/login",
+        viewTransition: true,
+        search: {
+          redirectTo: "/dashboard"
+        }
+      });
+    }
+  },
+  loader: getUserInfo,
+  pendingComponent: LoadingFullScreen
 });
 
 function RouteComponent() {
-  return <div>Hello /dashboard/!</div>;
+  const user = useUser();
+  const { data: userInfo } = useLoaderData({ from: "/dashboard/" });
+
+  if (!userInfo) {
+    throw new Error("User info not found");
+  }
+  const percentile = Math.round(
+    (userInfo.rank / userInfo.total_member_count) * 100
+  );
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50">
+      <div className="mb-2 p-4 max-w-[1280px] mx-auto">
+        <div className="rounded-2xl shadow-sm border border-gray-200 p-6 mb-6">
+          <div className="flex items-center justify-between md:flex-row flex-col gap-6">
+            <div className="flex items-center space-x-4">
+              <div className="w-16 h-16 bg-gradient-to-br from-primary-hover to-primary rounded-full flex items-center justify-center">
+                <User className="w-8 h-8 text-white" />
+              </div>
+              <div className="flex-1">
+                <h1 className="text-2xl font-bold break-all">
+                  {user?.nickname || "사용자"}
+                </h1>
+              </div>
+              <Rank rank={userInfo.rank} />
+            </div>
+            <div className="text-right flex items-center gap-5 flex-col md:flex-row">
+              <div className="flex items-center gap-2 ">
+                {/* 점수 표시 */}
+                <div className="flex items-center gap-2 text-lg font-semibold bg-gradient-to-br from-primary-hover to-primary text-text-light-solid rounded-xl px-4 py-2">
+                  <Star className="w-5 h-5" />
+                  <span>{userInfo?.score || 0}점</span>
+                </div>
+
+                {/* 토큰 표시 */}
+                <div className="flex items-center gap-2 text-lg font-semibold bg-gradient-to-br from-gold-4 to-gold-6 text-text-light-solid rounded-xl px-4 py-2">
+                  <Coins className="w-5 h-5" />
+                  <span>{userInfo?.token_count || 0} 토큰</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 랭킹 진행 바 */}
+          {userInfo && (
+            <div className="mt-6 pt-4 border-t border-gray-200">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm ">전체 멤버 중 위치</span>
+                <Percentile
+                  rank={userInfo.rank}
+                  totalMemberCount={userInfo.total_member_count}
+                />
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-2">
+                <div
+                  className="bg-gradient-to-r from-green-500 to-blue-500 h-2 rounded-full transition-all duration-500"
+                  style={{ width: `${100 - percentile}%` }}
+                />
+              </div>
+              <div className="flex justify-between mt-1 text-xs text-gray-500">
+                <span>{userInfo.total_member_count}위</span>
+                <span>1위</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+      <InterviewHistory />
+    </main>
+  );
 }

--- a/apps/kokomen-webview/src/store/index.ts
+++ b/apps/kokomen-webview/src/store/index.ts
@@ -1,0 +1,72 @@
+import { User } from "@kokomen/types/auth";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AuthState {
+  user: User | null;
+  isAuthenticated: boolean;
+}
+
+// 인증 액션 타입 정의
+interface AuthActions {
+  // eslint-disable-next-line no-unused-vars
+  setAuth: (user: User) => void;
+  clearAuth: () => void;
+  logout: () => void;
+}
+
+// 전체 스토어 타입
+type AuthStore = AuthState & AuthActions;
+
+// Zustand 스토어 - 인증 상태만 관리
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set) => ({
+      // 초기 상태
+      user: null,
+
+      isAuthenticated: false,
+
+      // 인증 정보 설정
+      setAuth: (user: User) => {
+        set({
+          user,
+          isAuthenticated: true
+        });
+      },
+
+      // 인증 정보 제거
+      clearAuth: () => {
+        set({
+          user: null,
+          isAuthenticated: false
+        });
+      },
+
+      // 로그아웃 (TanStack Query 캐시도 함께 정리)
+      logout: () => {
+        set({
+          user: null,
+          isAuthenticated: false
+        });
+        // TanStack Query 캐시 무효화는 컴포넌트에서 처리
+      }
+    }),
+    {
+      name: "auth-storage",
+      partialize: (state) => ({
+        user: state.user,
+        isAuthenticated: state.isAuthenticated
+      })
+    }
+  )
+);
+
+// 헬퍼 훅들
+export const useUser = (): User | null =>
+  useAuthStore((state) => {
+    if (!state.user) return null;
+    return state.user;
+  });
+export const useIsAuthenticated = (): boolean =>
+  useAuthStore((state) => state.isAuthenticated);

--- a/packages/kokomen-utils/src/general/querykeys.ts
+++ b/packages/kokomen-utils/src/general/querykeys.ts
@@ -71,11 +71,23 @@ const memberKeys: QueryKeyFactory<MemberMethods> = {
     [...memberKeys.all, "interviews", interviewId, sort, page] as const
 };
 
+interface MeMethods {
+  me: () => QueryKey;
+  detailedInfo: () => QueryKey;
+}
+const meKeys: QueryKeyFactory<MeMethods> = {
+  all: ["me"] as const,
+  me: (): QueryKey => [...meKeys.all] as const,
+  detailedInfo: (): QueryKey => [...meKeys.all, "detailedInfo"] as const
+};
+
 export {
   interviewHistoryKeys,
   interviewKeys,
   memberKeys,
+  meKeys,
   type InterviewHistoryParams,
   type InterviewParams,
-  type MemberRankParams
+  type MemberRankParams,
+  type MeMethods
 };

--- a/packages/types/src/auth/index.ts
+++ b/packages/types/src/auth/index.ts
@@ -1,11 +1,14 @@
 interface User {
   id: number;
   nickname: string;
-  score: number;
-  token_count: number;
   profile_completed: boolean;
+}
+
+interface UserInfo {
+  score: number;
   total_member_count: number;
+  token_count: number;
   rank: number;
 }
 
-export type { User };
+export type { User, UserInfo };

--- a/packages/ui/src/components/rank/index.tsx
+++ b/packages/ui/src/components/rank/index.tsx
@@ -35,14 +35,16 @@ export const Rank: React.FC<{ rank: number }> = ({ rank }) => {
       className={`${color} ${bgColor} inline-flex items-center rounded px-2 py-1`}
     >
       <Icon className="w-5 h-5 mr-1" />
-      {rank}
+      {rank}위
     </span>
   );
 };
 
-export const Percentile: React.FC<{ percentile: number }> = ({
-  percentile
-}) => {
+export const Percentile: React.FC<{
+  rank: number;
+  totalMemberCount: number;
+}> = ({ rank, totalMemberCount }) => {
+  const percentile = Math.round((rank / totalMemberCount) * 100);
   let color: string, bgColor: string;
   if (percentile >= 90) {
     color = "text-volcano-7";
@@ -76,7 +78,7 @@ export const Percentile: React.FC<{ percentile: number }> = ({
     <span
       className={`${color} ${bgColor} inline-flex items-center rounded px-2 py-1`}
     >
-      {percentile}%
+      상위 {percentile}%
     </span>
   );
 };

--- a/packages/ui/src/components/spinner/index.tsx
+++ b/packages/ui/src/components/spinner/index.tsx
@@ -1,3 +1,6 @@
+import { cn } from "#utils/index.ts";
+import { HTMLAttributes } from "react";
+
 function RoundSpinner() {
   return (
     <div role="status">
@@ -30,9 +33,15 @@ function LoadingCircles() {
   );
 }
 
-function LoadingFullScreen() {
+function LoadingFullScreen({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className="flex items-center justify-center h-full">
+    <div
+      className={cn(`flex items-center justify-center h-full`, className)}
+      {...props}
+    >
       <LoadingCircles />
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2922,6 +2922,7 @@ __metadata:
     vite: "npm:^7.0.4"
     vite-tsconfig-paths: "npm:^5.1.4"
     zod: "npm:^3.25.74"
+    zustand: "npm:^5.0.6"
   languageName: unknown
   linkType: soft
 
@@ -16173,7 +16174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^5.0.1, zustand@npm:^5.0.3":
+"zustand@npm:^5.0.1, zustand@npm:^5.0.3, zustand@npm:^5.0.6":
   version: 5.0.6
   resolution: "zustand@npm:5.0.6"
   peerDependencies:


### PR DESCRIPTION
## 📌 개요

웹뷰 대시보드 페이지를 추가하고, 로그인 유지 관련 기능을 zustand를 사용해서 구현했습니다.
zustand를 사용한 이유는 번들 사이즈가 가볍고, redux와 같은 복잡한 상태관리 라이브러리의 경우 복잡한 상태를 관리해야 하는데 비해 지금 관리해야 하는 상태는 유저 관련 간단한 정보밖에 없기 때문에 flux 철학을 따르는 zustand를 이용하여 데이터의 단방향 흐름을 유지하면서 사용할 수 있도록 하였습니다.

## ✅ 작업 내용

- [x] 로그인 유지 기능 구현
- [x] 웹뷰 인터뷰 페이지 추가

## 🧪 테스트

- [x] 직접 테스트 완료

## 📝 참고 사항

- 없음

## 📎 관련 이슈

Closes #90
Closes #88 
