### PR TITLE
hotfix: 배포 워크플로우에 의존성 설치 단계 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+      - name: install dependencies
+        run: |
+          corepack enable
+          yarn set version berry
+          yarn install
 
       - name: Run Docker Compose
         env:


### PR DESCRIPTION
메인 브랜치 배포 workflow 과정에서 의존성 설치 과정이 빠져있어 수정합니다.