### PR TITLE
[Feature/#166] - 구글 Oauth 웹뷰에서도 추가

### DIFF
--- a/apps/kokomen-webview/src/domains/auth/api/index.ts
+++ b/apps/kokomen-webview/src/domains/auth/api/index.ts
@@ -16,6 +16,16 @@ const postAuthorizationCode = async (
   });
 };
 
+const postGoogleAuthorizationCode = async (
+  code: string,
+  redirectUri: string
+): AxiosPromise<User> => {
+  return authServerInstance.post(`/auth/google-login`, {
+    code,
+    redirect_uri: redirectUri
+  });
+};
+
 const getUserInfo = async (): AxiosPromise<UserInfo & User> => {
   return authServerInstance.get(`/members/me/profile`);
 };
@@ -42,6 +52,7 @@ const deleteUser = async (): AxiosPromise<void> => {
 
 export {
   postAuthorizationCode,
+  postGoogleAuthorizationCode,
   getUserInfo,
   logout,
   updateUserProfile,

--- a/apps/kokomen-webview/src/main.tsx
+++ b/apps/kokomen-webview/src/main.tsx
@@ -56,8 +56,8 @@ function AuthRouter() {
   return <RouterProvider router={router} context={{ queryClient }} />;
 }
 
-posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_KEY, {
-  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
+  api_host: import.meta.env.VITE_POSTHOG_HOST,
   defaults: "2025-05-24"
 });
 

--- a/apps/kokomen-webview/src/routeTree.gen.ts
+++ b/apps/kokomen-webview/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as LoginProfileRouteImport } from './routes/login/profile'
 import { Route as LoginCallbackRouteImport } from './routes/login/callback'
 import { Route as InterviewsInterviewIdIndexRouteImport } from './routes/interviews/$interviewId/index'
 import { Route as MembersInterviewsInterviewIdRouteImport } from './routes/members/interviews.$interviewId'
+import { Route as LoginGoogleCallbackRouteImport } from './routes/login/google.callback'
 import { Route as InterviewsInterviewIdResultRouteImport } from './routes/interviews/$interviewId/result'
 
 const IndexRoute = IndexRouteImport.update({
@@ -79,6 +80,11 @@ const MembersInterviewsInterviewIdRoute =
     path: '/members/interviews/$interviewId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const LoginGoogleCallbackRoute = LoginGoogleCallbackRouteImport.update({
+  id: '/login/google/callback',
+  path: '/login/google/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const InterviewsInterviewIdResultRoute =
   InterviewsInterviewIdResultRouteImport.update({
     id: '/interviews/$interviewId/result',
@@ -97,6 +103,7 @@ export interface FileRoutesByFullPath {
   '/interviews': typeof InterviewsIndexRoute
   '/login': typeof LoginIndexRoute
   '/interviews/$interviewId/result': typeof InterviewsInterviewIdResultRoute
+  '/login/google/callback': typeof LoginGoogleCallbackRoute
   '/members/interviews/$interviewId': typeof MembersInterviewsInterviewIdRoute
   '/interviews/$interviewId': typeof InterviewsInterviewIdIndexRoute
 }
@@ -111,6 +118,7 @@ export interface FileRoutesByTo {
   '/interviews': typeof InterviewsIndexRoute
   '/login': typeof LoginIndexRoute
   '/interviews/$interviewId/result': typeof InterviewsInterviewIdResultRoute
+  '/login/google/callback': typeof LoginGoogleCallbackRoute
   '/members/interviews/$interviewId': typeof MembersInterviewsInterviewIdRoute
   '/interviews/$interviewId': typeof InterviewsInterviewIdIndexRoute
 }
@@ -126,6 +134,7 @@ export interface FileRoutesById {
   '/interviews/': typeof InterviewsIndexRoute
   '/login/': typeof LoginIndexRoute
   '/interviews/$interviewId/result': typeof InterviewsInterviewIdResultRoute
+  '/login/google/callback': typeof LoginGoogleCallbackRoute
   '/members/interviews/$interviewId': typeof MembersInterviewsInterviewIdRoute
   '/interviews/$interviewId/': typeof InterviewsInterviewIdIndexRoute
 }
@@ -142,6 +151,7 @@ export interface FileRouteTypes {
     | '/interviews'
     | '/login'
     | '/interviews/$interviewId/result'
+    | '/login/google/callback'
     | '/members/interviews/$interviewId'
     | '/interviews/$interviewId'
   fileRoutesByTo: FileRoutesByTo
@@ -156,6 +166,7 @@ export interface FileRouteTypes {
     | '/interviews'
     | '/login'
     | '/interviews/$interviewId/result'
+    | '/login/google/callback'
     | '/members/interviews/$interviewId'
     | '/interviews/$interviewId'
   id:
@@ -170,6 +181,7 @@ export interface FileRouteTypes {
     | '/interviews/'
     | '/login/'
     | '/interviews/$interviewId/result'
+    | '/login/google/callback'
     | '/members/interviews/$interviewId'
     | '/interviews/$interviewId/'
   fileRoutesById: FileRoutesById
@@ -185,6 +197,7 @@ export interface RootRouteChildren {
   InterviewsIndexRoute: typeof InterviewsIndexRoute
   LoginIndexRoute: typeof LoginIndexRoute
   InterviewsInterviewIdResultRoute: typeof InterviewsInterviewIdResultRoute
+  LoginGoogleCallbackRoute: typeof LoginGoogleCallbackRoute
   MembersInterviewsInterviewIdRoute: typeof MembersInterviewsInterviewIdRoute
   InterviewsInterviewIdIndexRoute: typeof InterviewsInterviewIdIndexRoute
 }
@@ -268,6 +281,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MembersInterviewsInterviewIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/login/google/callback': {
+      id: '/login/google/callback'
+      path: '/login/google/callback'
+      fullPath: '/login/google/callback'
+      preLoaderRoute: typeof LoginGoogleCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/interviews/$interviewId/result': {
       id: '/interviews/$interviewId/result'
       path: '/interviews/$interviewId/result'
@@ -289,6 +309,7 @@ const rootRouteChildren: RootRouteChildren = {
   InterviewsIndexRoute: InterviewsIndexRoute,
   LoginIndexRoute: LoginIndexRoute,
   InterviewsInterviewIdResultRoute: InterviewsInterviewIdResultRoute,
+  LoginGoogleCallbackRoute: LoginGoogleCallbackRoute,
   MembersInterviewsInterviewIdRoute: MembersInterviewsInterviewIdRoute,
   InterviewsInterviewIdIndexRoute: InterviewsInterviewIdIndexRoute,
 }

--- a/apps/kokomen-webview/src/routes/login/google.callback.tsx
+++ b/apps/kokomen-webview/src/routes/login/google.callback.tsx
@@ -1,0 +1,207 @@
+import { postGoogleAuthorizationCode } from "@/domains/auth/api";
+import { useAuthStore } from "@/store";
+import { useMutation } from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  useRouter,
+  useSearch
+} from "@tanstack/react-router";
+import React, { useEffect } from "react";
+
+// eslint-disable-next-line @rushstack/typedef-var
+export const Route = createFileRoute("/login/google/callback")({
+  component: RouteComponent
+});
+
+const ROOT_URI: string = "/interviews";
+function RouteComponent(): React.ReactNode {
+  const router = useRouter();
+  const { code, state } = useSearch({
+    from: "/login/google/callback",
+    select: (search) => search as { code?: string; state?: string }
+  });
+
+  const authMutation = useMutation({
+    mutationFn: ({
+      code,
+      redirectUri
+    }: {
+      code: string;
+      redirectUri: string;
+    }) => postGoogleAuthorizationCode(code, redirectUri),
+
+    onSuccess: ({ data }) => {
+      useAuthStore.getState().setAuth(data);
+      const redirectTo = state === "/" ? ROOT_URI : state || ROOT_URI;
+      if (!data.profile_completed) {
+        router.navigate({ to: `/login/profile?state=${redirectTo}` });
+        return;
+      }
+      router.navigate({ to: redirectTo, replace: true });
+    },
+
+    onError: (error) => {
+      console.error("로그인 실패:", error);
+    },
+    retry: 1
+  });
+
+  useEffect(() => {
+    if (authMutation.isPending || authMutation.error || authMutation.isSuccess)
+      return;
+
+    const redirectUri = `${import.meta.env.VITE_BASE_URL}/login/google/callback`;
+
+    authMutation.mutate({
+      code: code as string,
+      redirectUri
+    });
+  }, [code, state, authMutation]);
+
+  // 로딩 상태
+  if (authMutation.isPending) {
+    return (
+      <div className="bg-gray-50 flex items-center justify-center h-full">
+        <div className="max-w-md w-full text-center px-4">
+          <div className="bg-white rounded-lg shadow-lg p-8">
+            <div className="mx-auto w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mb-6">
+              <svg
+                className="animate-spin w-8 h-8 text-blue-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                ></circle>
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              로그인 처리 중...
+            </h2>
+            <p className="text-gray-600">구글 로그인을 완료하고 있습니다</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 성공 상태
+  if (authMutation.isSuccess) {
+    return (
+      <div className="h-full bg-gray-50 flex items-center justify-center">
+        <div className="max-w-md w-full text-center px-4">
+          <div className="bg-white rounded-lg shadow-lg p-8">
+            <div className="mx-auto w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mb-6">
+              <svg
+                className="w-8 h-8 text-green-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              로그인 완료!
+            </h2>
+            <p className="text-gray-600 mb-6">
+              구글 로그인이 성공적으로 완료되었습니다
+            </p>
+            <div className="space-y-4">
+              <div className="text-sm text-gray-500">
+                <span>페이지가 곧 이동됩니다...</span>
+              </div>
+              <Link
+                to={state || ROOT_URI}
+                className="inline-block w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-medium hover:bg-blue-700 transition-colors"
+              >
+                지금 이동하기
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (authMutation.isError) {
+    return (
+      <div className="h-full bg-gray-50 flex items-center justify-center">
+        <div className="max-w-md w-full text-center px-4">
+          <div className="bg-white rounded-lg shadow-lg p-8">
+            <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-6">
+              <svg
+                className="w-8 h-8 text-red-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              로그인 실패
+            </h2>
+            <p className="text-gray-600 mb-6">
+              로그인 처리 중 문제가 발생했습니다. 다시 시도해주세요.
+            </p>
+            <div className="space-y-3">
+              <button
+                onClick={() => {
+                  const redirectUri = `${import.meta.env.VITE_BASE_URL}/login/callback`;
+                  authMutation.mutate({ code, redirectUri } as {
+                    code: string;
+                    redirectUri: string;
+                  });
+                }}
+                className="w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-medium hover:bg-blue-700 transition-colors disabled:opacity-50"
+                disabled={authMutation.isPending}
+              >
+                다시 시도하기
+              </button>
+              <Link
+                to="/login"
+                className="inline-block w-full bg-gray-100 text-gray-700 py-3 px-6 rounded-lg font-medium hover:bg-gray-200 transition-colors"
+              >
+                로그인 페이지로 돌아가기
+              </Link>
+              <Link
+                to="/"
+                className="inline-block text-blue-600 hover:text-blue-800 text-sm"
+              >
+                홈으로 이동
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/apps/kokomen-webview/src/routes/login/index.tsx
+++ b/apps/kokomen-webview/src/routes/login/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useSearch } from "@tanstack/react-router";
+import { createFileRoute, Link, useSearch } from "@tanstack/react-router";
 import React from "react";
 
 // eslint-disable-next-line @rushstack/typedef-var
@@ -13,15 +13,19 @@ function RouteComponent(): React.ReactNode {
   });
   const redirectTo = `&state=${query.redirectTo ?? "/"}`;
   const redirectUri = `${import.meta.env.VITE_BASE_URL}/login/callback${redirectTo}`;
+  const googleRedirectUri = `${import.meta.env.VITE_BASE_URL}/login/google/callback${redirectTo}`;
   return (
     <>
-      <div className="h-full bg-gradient-to-br from-blue-50 via-white to-indigo-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8">
           {/* 로고 및 헤더 */}
-          <div className="text-center">
-            <h2 className="text-3xl font-bold text-gray-900 mb-2">로그인</h2>
+          <div className="text-center flex flex-col items-center space-y-4">
+            <img src="/icon.png" alt="꼬꼬면 로고" className="w-16 h-16" />
+            <h2 className="text-3xl font-bold text-gray-900 mb-2">
+              꼬꼬면에 로그인
+            </h2>
             <p className="text-gray-600">
-              로그인하고 AI 모의 면접 서비스를 체험해보세요!
+              면접 연습을 시작하려면 로그인이 필요합니다
             </p>
           </div>
 
@@ -30,48 +34,70 @@ function RouteComponent(): React.ReactNode {
               href={`${import.meta.env.VITE_API_BASE_URL}/auth/kakao-login?redirectUri=${redirectUri}`}
               className="w-full flex items-center justify-center px-4 py-3 border border-transparent rounded-xl text-base font-medium text-black bg-[#FEE500] hover:bg-[#FFEB3B] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-400 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-md hover:shadow-lg"
             >
-              <div className="flex items-center space-x-3">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+              <div className="flex items-center w-full">
+                <svg viewBox="0 0 24 24" fill="none" className="w-6 h-6">
                   <path
                     d="M12 3C6.48 3 2 6.24 2 10.32c0 2.52 1.68 4.8 4.32 6.12L5.52 20.4c-.12.36.36.6.6.36l3.84-2.64C10.56 18.24 11.28 18.36 12 18.36c5.52 0 10-3.24 10-7.32S17.52 3 12 3z"
                     fill="currentColor"
                   />
                 </svg>
-                <span>카카오로 시작하기</span>
+                <span className="flex-1 text-center">카카오로 시작하기</span>
+              </div>
+            </a>
+            <a
+              href={`${import.meta.env.VITE_API_BASE_URL}/auth/google-login?redirectUri=${googleRedirectUri}`}
+              className="w-full flex items-center px-4 py-3 border border-[#747775] rounded-full"
+            >
+              <div className="flex items-center w-full">
+                <svg
+                  version="1.1"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 48 48"
+                  className="w-6 h-6"
+                >
+                  <path
+                    fill="#EA4335"
+                    d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+                  ></path>
+                  <path
+                    fill="#4285F4"
+                    d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+                  ></path>
+                  <path
+                    fill="#FBBC05"
+                    d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+                  ></path>
+                  <path
+                    fill="#34A853"
+                    d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+                  ></path>
+                  <path fill="none" d="M0 0h48v48H0z"></path>
+                </svg>
+                <span className="flex-1 text-center">구글로 시작하기</span>
               </div>
             </a>
 
             <div className="text-center space-y-4">
               <div className="border-t border-gray-200 pt-4">
                 <p className="text-xs text-gray-500 leading-relaxed">
-                  로그인 시 꼬꼬면의{" "}
-                  <a
-                    href="/terms"
+                  로그인 시 꼬꼬면의
+                  <Link
+                    to="/terms/termsofuse"
                     className="text-blue-600 hover:text-blue-800 underline"
                   >
                     서비스 이용약관
-                  </a>
-                  과{" "}
-                  <a
-                    href="/privacy"
+                  </Link>
+                  과
+                  <Link
+                    to="/terms/privacy"
                     className="text-blue-600 hover:text-blue-800 underline"
                   >
                     개인정보 처리방침
-                  </a>
+                  </Link>
                   에 동의하게 됩니다.
                 </p>
               </div>
             </div>
-          </div>
-
-          {/* 하단 정보 */}
-          <div className="text-center">
-            <p className="text-sm text-gray-500">
-              처음 방문하시나요?{" "}
-              <span className="text-blue-600 font-medium">
-                카카오로 간편하게 가입하세요
-              </span>
-            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 📌 개요

구글 Oauth를 웹뷰에도 추가하여 출시 전에 로그인 수단을 추가할 수 있도록 하였습니다.
기존 구글 로그인 API나 라우트 설계 등은 클라이언트와 대부분 동일합니다.

## ✅ 작업 내용

- [x] 추가 : 구글 Oauth 웹뷰에서 로그인 수단 추가
- [x] 버그 수정 : posthog initialize 문제 env 변수명 변경으로 해결

## 🧪 테스트

- [x] 직접 테스트 완료

## 📝 참고 사항

- 없음

## 📎 관련 이슈

Closes #166
